### PR TITLE
Remove extra menu items in File menu

### DIFF
--- a/source/PluginDev/Assets/Editor/GPGSAndroidSetupUI.cs
+++ b/source/PluginDev/Assets/Editor/GPGSAndroidSetupUI.cs
@@ -27,11 +27,6 @@ public class GPGSAndroidSetupUI : EditorWindow {
         EditorWindow.GetWindow(typeof(GPGSAndroidSetupUI));
     }
 
-    [MenuItem("File/Play Games - Android setup...")]
-    public static void MenuItemFileGPGSAndroidSetup() {
-        EditorWindow.GetWindow(typeof(GPGSAndroidSetupUI));
-    }
-
     void OnEnable() {
         mAppId = GPGSProjectSettings.Instance.Get("proj.AppId");
     }

--- a/source/PluginDev/Assets/Editor/GPGSIOSSetupUI.cs
+++ b/source/PluginDev/Assets/Editor/GPGSIOSSetupUI.cs
@@ -29,11 +29,6 @@ public class GPGSIOSSetupUI : EditorWindow {
         EditorWindow.GetWindow(typeof(GPGSIOSSetupUI));
     }
 
-    [MenuItem("File/Play Games - iOS setup...")]
-    public static void MenuItemFileGPGSIOSSetup() {
-        EditorWindow.GetWindow(typeof(GPGSIOSSetupUI));
-    }
-
     void OnEnable() {
         mAppId = GPGSProjectSettings.Instance.Get("proj.AppId");
         mClientId = GPGSProjectSettings.Instance.Get("ios.ClientId");


### PR DESCRIPTION
The duplicate menu items in the File menu aren't needed and just take up space. It's also unintuitive that 'Exit' isn't the last item in the File menu.

This pull request removes the duplicated items from the File menu.
