### PR TITLE
Optimize JNI to managed byte array conversion in JavaUtil

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/JavaUtil.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/JavaUtil.cs
@@ -90,7 +90,7 @@ namespace GooglePlayGames.Android {
         public static byte[] ConvertByteArray(AndroidJavaObject byteArrayObj) {
             Debug.Log("ConvertByteArray.");
             
-            if (byteArrayObj == null) {
+            if (byteArrayObj == null || byteArrayObj.GetRawObject().ToInt32() == 0) {
                 return null;
             }
             


### PR DESCRIPTION
Unity provides a helper method to convert a Java array into a managed
array which is much quicker than making repeated overhead-heavy
AndroidJavaClass::CallStatic "getByte" calls.

(this was a huge speedup factor for long byte arrays in my project)
