### PR TITLE
Adding support for silent sign-in to iOS

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/iOS/IOSClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/iOS/IOSClient.cs
@@ -47,7 +47,7 @@ namespace GooglePlayGames.IOS {
 
         // Entry points exposed by the iOS native code (.m files in Assets/Plugins/iOS):
         [DllImport("__Internal")]
-        private static extern void GPGSAuthenticateWithCallback(GPGSSuccessCallback cb);
+        private static extern bool GPGSAuthenticateWithCallback(GPGSSuccessCallback cb, bool silent);
 
         [DllImport("__Internal")]
         private static extern void GPGSEnableDebugLog(bool enable);
@@ -152,7 +152,10 @@ namespace GooglePlayGames.IOS {
         public void Authenticate(System.Action<bool> callback, bool silent) {
             Logger.d("IOSClient.Authenticate");
             mAuthCallback = callback;
-            GPGSAuthenticateWithCallback(AuthCallback);
+            // Authenticate currently returns void, so there's nothing
+            // we can do with this value right now beyond log it
+            bool tryingSilentSignIn = GPGSAuthenticateWithCallback(AuthCallback, silent);
+            Logger.d("Trying silent signin = " + tryingSilentSignIn);
         }
         
         public void SignOut() {

--- a/source/PluginDev/Assets/MainGui.cs
+++ b/source/PluginDev/Assets/MainGui.cs
@@ -73,8 +73,10 @@ public class MainGui : MonoBehaviour, GooglePlayGames.BasicApi.OnStateLoadedList
     void ShowNotAuthUi() {
         DrawTitle(null);
         DrawStatus();
-        if (GUI.Button(CalcGrid(1,1), "Authenticate")) {
-            DoAuthenticate();
+        if (GUI.Button(CalcGrid(1, 1), "Authenticate")) {
+            DoAuthenticate(false);
+        } else if (GUI.Button(CalcGrid(1, 2), "Silent Auth")) {
+            DoAuthenticate(true);
         }
     }
 
@@ -253,12 +255,14 @@ public class MainGui : MonoBehaviour, GooglePlayGames.BasicApi.OnStateLoadedList
         mStandby = false;
     }
 
-    void DoAuthenticate() {
-        SetStandBy("Authenticating...");
+    void DoAuthenticate(bool silent) {
+        if (!silent) {
+            SetStandBy("Authenticating...");
+        }
 
         PlayGamesPlatform.DebugLogEnabled = true;
         PlayGamesPlatform.Activate();
-        Social.localUser.Authenticate((bool success) => {
+        PlayGamesPlatform.Instance.Authenticate((bool success) => {
             EndStandBy();
             if (success) {
                 mStatus = "Authenticated. Hello, " + Social.localUser.userName + " (" +
@@ -271,7 +275,7 @@ public class MainGui : MonoBehaviour, GooglePlayGames.BasicApi.OnStateLoadedList
                 mStatus = "*** Failed to authenticate.";
             }
             ShowEffect(success);
-        });
+        }, silent);
     }
 
     void DoSignOut() {

--- a/source/PluginDev/Assets/Plugins/iOS/GPGSInterface.m
+++ b/source/PluginDev/Assets/Plugins/iOS/GPGSInterface.m
@@ -27,9 +27,10 @@
 
 // This file defines entry points to be called from C#.
 
-void GPGSAuthenticateWithCallback(GPGSSuccessCallback cb) {
+GPGSBOOL GPGSAuthenticateWithCallback(GPGSSuccessCallback cb, BOOL silently) {
   LOGD((@"GPGSAuthenticateWithCallback."));
-  [[GPGSManager instance] authenticateWithCallback: cb];
+  BOOL tryingSilentSignIn = [[GPGSManager instance] authenticateWithCallback:cb silently:silently];
+  return (tryingSilentSignIn) ? GPGSTRUE : GPGSFALSE;
 }
 
 void GPGSEnableDebugLog(GPGSBOOL enable) {

--- a/source/PluginDev/Assets/Plugins/iOS/GPGSManager.h
+++ b/source/PluginDev/Assets/Plugins/iOS/GPGSManager.h
@@ -26,7 +26,7 @@
 }
 - (GPGSManager*)init;
 + (GPGSManager*)instance;
-- (void) authenticateWithCallback:(GPGSSuccessCallback)callback;
+- (BOOL) authenticateWithCallback:(GPGSSuccessCallback)callback silently:(BOOL)trySilent;
 - (void) signOut;
 - (NSString*) playerId;
 - (NSString*) playerName;

--- a/source/PluginDev/Assets/Plugins/iOS/GPGSManager.m
+++ b/source/PluginDev/Assets/Plugins/iOS/GPGSManager.m
@@ -33,15 +33,16 @@ static GPGSManager *sInstance = NULL;
     return self;
 }
 
-- (void) authenticateWithCallback:(GPGSSuccessCallback)callback
+- (BOOL)authenticateWithCallback:(GPGSSuccessCallback)callback silently:(BOOL)trySilent
 {
     LOGD((@"GPGSManager initializing and authenticating."));
     mAuthCallback = callback;
     [GPGManager sharedInstance].statusDelegate = self;
 
+    [GPGManager sharedInstance].sdkTag = 0xa227;
     // Let's not break anybody currently using app state
     [GPGManager sharedInstance].appStateEnabled = YES;
-    [[GPGManager sharedInstance] signInWithClientID:@kClientID silently:NO];
+    return [[GPGManager sharedInstance] signInWithClientID:@kClientID silently:trySilent];
 }
 
 - (void)didFinishGamesSignInWithError:(NSError *)error {


### PR DESCRIPTION
Adding support to allow silent sign-in on iOS, which has been missing. Also, added a second button to the smoke test app to test this, and brought back our missing sdkTag.
