### PR TITLE
Discarding user ID and name during sign out

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
@@ -299,6 +299,8 @@ namespace GooglePlayGames.Android {
                 Logger.d("Calling GHM.SignOut");
                 mGHManager.SignOut();
                 mAuthState = AuthState.NoAuth;
+                mUserId = null;
+                mUserDisplayName = null;
                 mSignOutInProgress = false;
                 Logger.d("Now signed out.");
             });


### PR DESCRIPTION
Fixing issue #226 described here:
https://github.com/playgameservices/play-games-plugin-for-unity/issues/226
1. Sign in with account_1
2. Sign out
3. Sign in with account_2

Methods GetUserId() and GetUserDisplayName() will still return ID and name for account_1 because mUserId and mUserDisplayName weren't reset to null during sign out. Notice that RetrieveUserInfo() will only set mUserId and mUserDisplayName to their corresponding values when mUserId == null and mUserDisplayName == null.
