### PR TITLE
Quick implementation of LoadAchievements

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/Achievement.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/Achievement.cs
@@ -15,9 +15,10 @@
  */
 
 using System;
+using UnityEngine.SocialPlatforms;
 
 namespace GooglePlayGames.BasicApi {
-    public class Achievement {
+    public class Achievement : IAchievement{
         public string Id = "";
         public bool IsIncremental = false;
         public bool IsRevealed = false;
@@ -35,7 +36,56 @@ namespace GooglePlayGames.BasicApi {
         }
 
         public Achievement() {
+		}
+
+		#region IAchievement implementation
+
+        public void ReportProgress(Action<bool> callback)
+        {
+            PlayGamesPlatform.Instance.ReportProgress(Id, percentCompleted, callback);
         }
+
+        public bool completed
+        {
+            get { return IsUnlocked; }
+        }
+
+        public bool hidden
+        {
+            get { return !IsRevealed; }
+        }
+
+        public string id
+        {
+            get
+            {
+                return Id;
+            }
+            set
+            {
+                Id = value;
+            }
+        }
+
+        public DateTime lastReportedDate
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public double percentCompleted
+        {
+            get
+            {
+                return (double)CurrentSteps / (double)TotalSteps;
+            }
+            set
+            {
+                CurrentSteps = (int)Math.Round(TotalSteps * value / 100.0);
+            }
+        }
+
+		#endregion
+
     }
 }
 

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -67,6 +67,9 @@ namespace GooglePlayGames.BasicApi {
         // Return a specific achievement
         Achievement GetAchievement(string achId);
 
+		// Return a list of all achievements
+		List<Achievement> GetAchievements();
+
         // Unlock achievement
         void UnlockAchievement(string achId, Action<bool> callback);
 

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -369,12 +369,12 @@ namespace GooglePlayGames {
         }
 
         /// <summary>
-        /// Not implemented yet. Calls the callback with an empty list.
+        /// Load the achievements.
         /// </summary>
+        /// <param name="callback">Callback.</param>
         public void LoadAchievements(Action<IAchievement[]> callback) {
-            Logger.w("PlayGamesPlatform.LoadAchievements is not implemented.");
             if (callback != null) {
-                callback.Invoke(new IAchievement[0]);
+                callback.Invoke(mClient.GetAchievements().ToArray());
             }
         }
 

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/iOS/IOSClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/iOS/IOSClient.cs
@@ -215,6 +215,12 @@ namespace GooglePlayGames.IOS {
             return a;
         }
 
+        public List<Achievement> GetAchievements()
+        {
+            Logger.w("IOSClient.GetAchievements is not implemented.");
+            return new List<Achievement>();
+        }
+
         public void UnlockAchievement(string achId, System.Action<bool> callback) {
             Logger.d("IOSClient.UnlockAchievement, achId=" + achId);
 


### PR DESCRIPTION
Made Achievements implement unity's UnityEngine.SocialPlatforms.IAchievement.
This allows the PlayGamesPlatform to actually implement the LoadAchievements method. 
Only works for Android.
IOS does not use the AchievementBank. I found this quick fix but have not digged any deeper into to the package so I cant solve it for IOS.
Also I noticed the PlayGamesAchievement class, which seems to be designed for a similar purpose, but it seems to be used nowhere.

I hope this is helpful!

Cheers,

Tobi