### PR TITLE
Added the score reception functionality - method LoadCurrentScore

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using UnityEngine.SocialPlatforms;
 using System;
 using System.Collections.Generic;
 using System.Collections;
@@ -77,7 +76,7 @@ namespace GooglePlayGames.BasicApi {
                 callback.Invoke(false);
             }
         }
-        public void ReceiveScore (string lbId, int span, int collection, Action<IScore> callback)
+        public void ReceiveScore (string lbId, int span, int collection, Action<PlayGamesScore> callback)
     	{
     		if(callback != null) {
     			callback.Invoke(null);

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using UnityEngine.SocialPlatforms;
 using System;
 using System.Collections.Generic;
 using System.Collections;
@@ -66,15 +67,22 @@ namespace GooglePlayGames.BasicApi {
             if (callback != null) {
                 callback.Invoke(false);
             }
-        }
+		}
 
         public void ShowAchievementsUI() {}
         public void ShowLeaderboardUI(string lbId) {}
+		
         public void SubmitScore(string lbId, long score, Action<bool> callback) {
             if (callback != null) {
                 callback.Invoke(false);
             }
         }
+        public void ReceiveScore (string lbId, int span, int collection, Action<IScore> callback)
+    	{
+    		if(callback != null) {
+    			callback.Invoke(null);
+    		}
+    	}
 
         public void LoadState(int slot, OnStateLoadedListener listener) {
             if (listener != null) {
@@ -95,6 +103,7 @@ namespace GooglePlayGames.BasicApi {
         public Invitation GetInvitationFromNotification() { return null; }
         
         public bool HasInvitationFromNotification() { return false; }
+        
     }
 }
 

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using UnityEngine.SocialPlatforms;
 using System;
 using System.Collections.Generic;
 using System.Collections;
@@ -84,6 +85,10 @@ namespace GooglePlayGames.BasicApi {
 
         // Report a score to given leaderboard
         void SubmitScore(string lbId, long score, Action<bool> callback);
+        
+        // Receive a score from a given leaderboard
+        // according to its span and collection - check out LeaderboardConsts
+		void ReceiveScore(string lbId, int span, int collection, Action<IScore> callback);
 
         // Set the buffer encrypter/decrypter used when saving cloud data to local storage.
         // This is only used in platforms where local storage of cloud data is not

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using UnityEngine.SocialPlatforms;
 using System;
 using System.Collections.Generic;
 using System.Collections;
@@ -88,7 +87,7 @@ namespace GooglePlayGames.BasicApi {
         
         // Receive a score from a given leaderboard
         // according to its span and collection - check out LeaderboardConsts
-		void ReceiveScore(string lbId, int span, int collection, Action<IScore> callback);
+		void ReceiveScore(string lbId, int span, int collection, Action<PlayGamesScore> callback);
 
         // Set the buffer encrypter/decrypter used when saving cloud data to local storage.
         // This is only used in platforms where local storage of cloud data is not

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/LeaderboardConsts.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/LeaderboardConsts.cs
@@ -1,0 +1,13 @@
+
+namespace GooglePlayGames.BasicApi {
+	internal class LeaderboardConsts {
+		// leaderboard collection types
+		public const int COLLECTION_PUBLIC = 0x01;
+		public const int COLLECTION_SOCIAL = 0x02;
+		
+		// leaderboard time spans
+		public const int TIME_SPAN_ALL_TIME = 0x02;
+		public const int TIME_SPAN_DAILY    = 0x00;
+		public const int TIME_SPAN_WEEKLY   = 0x01;
+	}
+}

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -417,8 +417,43 @@ namespace GooglePlayGames {
             string lbId = MapId(board);
             mClient.SubmitScore(lbId, score, callback);
         }
-
-        /// <summary>
+        
+		/// <summary>
+		/// Receives this user score.
+		/// </summary>
+		/// <param name='board'>
+		/// The ID of the leaderboard from which the score is to be received. This may be a raw
+		/// Google Play Games leaderboard ID or an alias configured through a call to
+		/// <see cref="AddIdMapping" />.
+		/// </param>
+		/// <param name='span'>
+		/// Time span to retrieve data for. 
+		/// Valid values are in the <c>LeaderboardScore</c> class.
+		/// </param>
+		/// <param name='collection'>
+		/// The leaderboard collection to retrieve scores for. 
+		/// Valid values are in the <c>LeaderboardScore</c> class.
+		/// </param>
+		/// <param name='callback'>
+		/// The callback to call to report the received score. The callback
+		/// will be called with <c>LeaderboardScore</c> istance, containing
+		/// all the necessary data about current score or <c>null</c> if an error occured.
+		/// </param>
+		public void LoadCurrentScore(string board, int span, int collection, Action<IScore> callback) {
+			if (!IsAuthenticated()) {
+				Logger.e("LoadCurrentScore can only be called after authentication.");
+				if (callback != null) {
+					callback.Invoke(null);
+				}
+				return;
+			}
+			
+			Logger.d("LoadCurrentScore: span=" + span + ", collection=" + collection + ", board=" + board);
+			string lbId = MapId(board);
+			mClient.ReceiveScore(lbId, span, collection, callback);
+		}
+		
+		/// <summary>
         /// Not implemented yet. Calls the callback with an empty list.
         /// </summary>
         public void LoadScores(string leaderboardID, Action<IScore[]> callback) {

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -450,7 +450,7 @@ namespace GooglePlayGames {
 			
 			Logger.d("LoadCurrentScore: span=" + span + ", collection=" + collection + ", board=" + board);
 			string lbId = MapId(board);
-			mClient.ReceiveScore(lbId, span, collection, callback);
+			mClient.ReceiveScore(lbId, span, collection, (PlayGamesScore score) => { callback.Invoke(score); } );
 		}
 		
 		/// <summary>

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesScore.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesScore.cs
@@ -25,6 +25,17 @@ namespace GooglePlayGames {
     public class PlayGamesScore : IScore {
         string mLbId = null;
         long mValue = 0;
+        long mTimestamp = 0;
+        int mRank = 0;
+        
+        internal PlayGamesScore() {}
+        
+		public PlayGamesScore (string mLbId, long timestamp, int rankValue, long value) {
+    		this.mLbId = mLbId;
+			this.mTimestamp = timestamp;
+			this.mRank = rankValue;
+			this.mValue = value;
+    	}
 
         /// <summary>
         /// Reports the score. Equivalent to <see cref="PlayGamesPlatform.ReportScore" />.
@@ -65,11 +76,11 @@ namespace GooglePlayGames {
         }
 
         /// <summary>
-        /// Not implemented. Returns Jan 01, 1970, 00:00:00
+        /// Returns the date of the last score update.
         /// </summary>
         public DateTime date {
             get {
-                return new DateTime(1970, 1, 1, 0, 0, 0);
+				return new DateTime(mTimestamp).AddYears(1970);
             }
         }
 
@@ -92,12 +103,17 @@ namespace GooglePlayGames {
         }
 
         /// <summary>
-        /// Not implemented. Returns 1.
+        /// Returns player rank in the leaderboard.
         /// </summary>
         public int rank {
             get {
-                return 1;
+                return mRank;
             }
         }
+        
+        public override string ToString ()
+    	{
+			return string.Format ("[PlayGamesScore: leaderboardID={0}, value={1}, date={2}, Timestamp={3}, rank={4}]", leaderboardID, value, date, mTimestamp, rank);
+    	}
     }
 }

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
@@ -17,7 +17,6 @@
 #if UNITY_ANDROID
 using System;
 using UnityEngine;
-using UnityEngine.SocialPlatforms;
 using System.Collections;
 using System.Collections.Generic;
 using GooglePlayGames.BasicApi;
@@ -343,10 +342,10 @@ namespace GooglePlayGames.Android {
 		
 		private class OnLeaderboardScoreReceivedProxy : AndroidJavaProxy {
 			AndroidClient mOwner;
-			Action<IScore> receiver;
+			Action<PlayGamesScore> receiver;
 			string mLbId;
 			
-			internal OnLeaderboardScoreReceivedProxy(AndroidClient c, string lbId, Action<IScore> callback) :
+			internal OnLeaderboardScoreReceivedProxy(AndroidClient c, string lbId, Action<PlayGamesScore> callback) :
 			base(JavaConsts.ResultCallbackClass) {
 				mOwner = c;
 				mLbId = lbId;
@@ -376,7 +375,7 @@ namespace GooglePlayGames.Android {
 					long value = scoreObj.Call<long>("getRawScore");
 					long timestamp = scoreObj.Call<long>("getTimestampMillis");
 					
-					IScore score = new PlayGamesScore(mLbId, timestamp, rank, value);
+					PlayGamesScore score = new PlayGamesScore(mLbId, timestamp, rank, value);
 					
 					Logger.d(score.ToString());
 					
@@ -569,7 +568,7 @@ namespace GooglePlayGames.Android {
         }
         
 		// called from game thread
-		public void ReceiveScore(string lbId, int span, int collection, Action<IScore> callback) {
+		public void ReceiveScore(string lbId, int span, int collection, Action<PlayGamesScore> callback) {
 			Logger.d("AndroidClient.ReceiveScore, lb=" + lbId + ", span=" + span + "collection=" + collection);
 			if(callback == null) {
 				Logger.d("Null callback passed, nowhere to send the result. Aborting.");


### PR DESCRIPTION
For the issue #189
Usage example: 
    
    using GooglePlayGames.BasicApi;
    ...
    PlayGamesPlatform.Instance.LoadCurrentScore(  
                               boardID, 
                               LeaderboardConsts.TIME_SPAN_ALL_TIME,
                               LeaderboardConsts.COLLECTION_PUBLIC,
                               (IScore score) => { if(score != null) Debug.Log(score.value); } 
                               );

For now, only works on Android as I have no iOS devices. Sorry. 
Also, there seems to be a bug of unknown etymology - changes to the scores, issued with the ReportScore, are shown immidiately in the Leaderboards UI, but are delayed for approximately a minute when querying using LoadCurrentState. 