### PR TITLE
Change ReportProgress behavior to be consistent with documentation

### DIFF
--- a/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/PlayGamesPlatformTest.cs
+++ b/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/PlayGamesPlatformTest.cs
@@ -114,7 +114,7 @@ namespace GooglePlayGames.UnitTests {
             Achievement nonIncremental = new Achievement();
             mockClient.CurrentAchievement = nonIncremental;
 
-            platform.ReportProgress("nonIncremental", 0.5, SentinelCallback);
+            platform.ReportProgress("nonIncremental", 50, SentinelCallback);
 
             Assert.AreEqual("nonIncremental", mockClient.UnlockedId);
             Assert.AreEqual(SentinelCallback, mockClient.UnlockedCallback);
@@ -125,7 +125,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            platform.ReportProgress("unknown", 0.5, SentinelCallback);
+            platform.ReportProgress("unknown", 50, SentinelCallback);
 
             Assert.AreEqual("unknown", mockClient.UnlockedId);
             Assert.AreEqual(SentinelCallback, mockClient.UnlockedCallback);
@@ -136,7 +136,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            IncrementViaReportProgress(mockClient, platform, 0, 100, 1.0);
+            IncrementViaReportProgress(mockClient, platform, 0, 100, 100);
 
             Assert.AreEqual("incremental", mockClient.IncrementedId);
             Assert.AreEqual(100, mockClient.IncrementedSteps.Value);
@@ -147,7 +147,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            IncrementViaReportProgress(mockClient, platform, 0, 100, 0.25);
+            IncrementViaReportProgress(mockClient, platform, 0, 100, 25);
 
             Assert.AreEqual("incremental", mockClient.IncrementedId);
             Assert.AreEqual(25, mockClient.IncrementedSteps.Value);
@@ -158,7 +158,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            IncrementViaReportProgress(mockClient, platform, 25, 100, 0.6);
+            IncrementViaReportProgress(mockClient, platform, 25, 100, 60);
 
             Assert.AreEqual("incremental", mockClient.IncrementedId);
             // Our target is 50 steps, initial value is 25 - delta of 25.
@@ -170,7 +170,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            IncrementViaReportProgress(mockClient, platform, 25, 100, 0.1);
+            IncrementViaReportProgress(mockClient, platform, 25, 100, 10);
 
             Assert.IsNull(mockClient.IncrementedId);
             Assert.IsNull(mockClient.IncrementedSteps);
@@ -181,7 +181,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            IncrementViaReportProgress(mockClient, platform, 25, 100, 0.25);
+            IncrementViaReportProgress(mockClient, platform, 25, 100, 25);
 
             Assert.IsNull(mockClient.IncrementedId);
             Assert.IsNull(mockClient.IncrementedSteps);
@@ -192,7 +192,7 @@ namespace GooglePlayGames.UnitTests {
             var mockClient = new AchievementClient();
             var platform = new PlayGamesPlatform(mockClient);
 
-            IncrementViaReportProgress(mockClient, platform, 0, 100, 2.0);
+            IncrementViaReportProgress(mockClient, platform, 0, 100, 200);
 
             Assert.AreEqual("incremental", mockClient.IncrementedId);
             Assert.AreEqual(200, mockClient.IncrementedSteps.Value);

--- a/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/PlayGamesPlatformTest.cs
+++ b/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/PlayGamesPlatformTest.cs
@@ -116,8 +116,8 @@ namespace GooglePlayGames.UnitTests {
 
             platform.ReportProgress("nonIncremental", 50, SentinelCallback);
 
-            Assert.AreEqual("nonIncremental", mockClient.UnlockedId);
-            Assert.AreEqual(SentinelCallback, mockClient.UnlockedCallback);
+            Assert.IsNull(mockClient.UnlockedId);
+            Assert.IsNull(mockClient.UnlockedCallback);
         }
 
         [Test]
@@ -127,8 +127,8 @@ namespace GooglePlayGames.UnitTests {
 
             platform.ReportProgress("unknown", 50, SentinelCallback);
 
-            Assert.AreEqual("unknown", mockClient.UnlockedId);
-            Assert.AreEqual(SentinelCallback, mockClient.UnlockedCallback);
+            Assert.IsNull(mockClient.UnlockedId);
+            Assert.IsNull(mockClient.UnlockedCallback);
         }
 
         [Test]

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -314,7 +314,7 @@ public class PlayGamesPlatform : ISocialPlatform {
             // increment it to the target percentage (approximate)
             Logger.d("Progress " + progress +
             " interpreted as incremental target (approximate).");
-            int targetSteps = (int)(progress * totalSteps);
+            int targetSteps = (int)((progress / 100) * totalSteps);
             int numSteps = targetSteps - curSteps;
             Logger.d("Target steps: " + targetSteps + ", cur steps:" + curSteps);
             Logger.d("Steps to increment: " + numSteps);

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -321,10 +321,13 @@ public class PlayGamesPlatform : ISocialPlatform {
             if (numSteps > 0) {
                 mClient.IncrementAchievement(achievementID, numSteps, callback);
             }
-        } else {
+        } else if (progress >= 100) {
             // unlock it!
             Logger.d("Progress " + progress + " interpreted as UNLOCK.");
             mClient.UnlockAchievement(achievementID, callback);
+        } else {
+            // not enough to unlock
+            Logger.d("Progress " + progress + " not enough to unlock non-incremental achievement.");
         }
     }
 

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -314,6 +314,10 @@ public class PlayGamesPlatform : ISocialPlatform {
             // increment it to the target percentage (approximate)
             Logger.d("Progress " + progress +
             " interpreted as incremental target (approximate).");
+            if (progress >= 0.0 && progress <= 1.0) {
+                // in a previous version, incremental progress was reported by using the range [0-1]
+                Logger.w("Progress " + progress + " is less than or equal to 1. You might be trying to use values in the range of [0,1], while values are expected to be within the range [0,100]. If you are using the latter, you can safely ignore this message.");
+            }
             int targetSteps = (int)((progress / 100) * totalSteps);
             int numSteps = targetSteps - curSteps;
             Logger.d("Target steps: " + targetSteps + ", cur steps:" + curSteps);


### PR DESCRIPTION
This addresses two separate inconsistencies in the behavior of ReportProgress relative to other game services platforms:

1. ReportProgress is documented as receiving a ``progress`` parameter between 0.0 to 100.0.  The code was instead assuming a value in the range [0.0, 1.0].  Using a value of 0 to 100 is consistent with [Unity's Social.ReportProgress](http://docs.unity3d.com/ScriptReference/Social.ReportProgress.html).

2. Specifying any ``progress`` value greater than 0 would unlock the achievement.  This requires the developer to query the achievement ahead of time to prevent erroneously unlocking a non-incremental achievement.  Restricting unlocks to ``progress`` values >= 100 allows a developer to treat achievements as incremental and expect non-incremental achievements to only unlock when the player has completed all steps.  It's then only the app administrator's responsibility to determine if an achievement is better suited to be incremental or non-incremental, and can change the type in the developer console without changing the code.