### PR TITLE
Do not allocated a pinned GCHandle

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/Callbacks.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/Callbacks.cs
@@ -52,10 +52,9 @@ static class Callbacks {
         // the garbage collector runs before the native code invokes the callback, chaos will
         // ensue.
         //
-        // To handle this, we manually pin the callback in memory (this means it cannot be
-        // collected or moved) - the GCHandle will be freed when the callback returns the and
-        // handle is converted back to callback via IntPtrToCallback.
-        var handle = GCHandle.Alloc(callback, GCHandleType.Pinned);
+        // To handle this, we create a normal GCHandle. The GCHandle will be freed when the
+		// callback returns the and handle is converted back to callback via IntPtrToCallback.
+        var handle = GCHandle.Alloc(callback);
 
         return GCHandle.ToIntPtr(handle);
     }


### PR DESCRIPTION
Per MSDN
(https://msdn.microsoft.com/en-us/library/vstudio/a95009h1(v=vs.100).asp
x), an attempt to pin a GCHandle for a non-blittable type should throw
an argument exception. The type System.Delegate is non-blittable.

The version of Mono used by Unity does not throw an exception, but the
IL2CPP scripting backend does throw this exception. Therefore, this
code does not work with IL2CPP.

However, it should not be necessary to pin this GCHandle. A normal mode
handle should ensures that the managed object will not be collected.