### PR TITLE
#473 - Added GetAchievement method to PlayGamesPlatform

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -279,6 +279,24 @@ public class PlayGamesPlatform : ISocialPlatform {
         return mClient.GetUserImageUrl();
     }
 
+    /// <summary>
+    /// Returns the achievement corresponding to the passed achievement identifier.
+    /// </summary>
+    /// <returns>
+    /// The achievement corresponding to the identifer. <code>null</code> if no such
+    /// achievement is found or if the user is not authenticated.
+    /// </returns>
+    /// <param name="achievementId">
+    /// The identifier of the achievement.
+    /// </param>
+    public Achievement GetAchievement(string achievementId) {
+        if (!IsAuthenticated()) {
+            Logger.e("GetAchievement can only be called after authentication.");
+            return null;
+        }
+        return mClient.GetAchievement(achievementId);
+    }
+
 
     /// <summary>
     /// Reports the progress of an achievement (reveal, unlock or increment). This method attempts


### PR DESCRIPTION
When trying to integrate Google Play Games into my Unity3D game, I found that there was no access to the internal method `GetAchievement(achievementId)` via the `PlayGamesPlatform` class.

This method is really useful, as for incremental achievements it allows you to retrieve the currently completed steps and work out how many extra steps the player has completed.

Without this method, tons of data needs to be stored locally, to ensure that the correct increment is reported and to handle the device going offline, or the request to increment the achievement failing for some other reason.

Whereas with the above method you can just store the steps completed on device. Then, every time you want to report it do:

`stepsCompleted - GetAchievement(id).currentSteps`

This pull request adds a method to PlayGamesPlatform, that gives you access to this functionality.