### PR TITLE
Update GPGSDocsUI.cs

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSDocsUI.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSDocsUI.cs
@@ -70,7 +70,7 @@ namespace GooglePlayGames
                 string exeName =
                     sdkPath + GPGSUtil.SlashesToPlatformSeparator("/tools/android");
                 string altExeName =
-                    sdkPath + GPGSUtil.SlashesToPlatformSeparator("/tools/android.exe");
+                    sdkPath + GPGSUtil.SlashesToPlatformSeparator("/tools/android.bat");
 
                 EditorUtility.DisplayDialog(
                     GPGSStrings.ExternalLinks.GooglePlayGamesAndroidSdkTitle,


### PR DESCRIPTION
The file "Android.exe" no longer exists in the current Android SDK "/tools/" path. It is now recommended to execute "/tools/android.bat" or "sdk manager.exe" in the root "/sdk/" folder