### PR TITLE
GPGSPostBuild.cs function parameters format fix

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSPostBuild.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSPostBuild.cs
@@ -68,10 +68,7 @@ namespace GooglePlayGames
             UpdateGeneratedInfoPlistFile(pathToBuiltProject + "/Info.plist");
             UpdateGeneratedPbxproj(pathToBuiltProject + "/Unity-iPhone.xcodeproj/project.pbxproj");
 
-            EditorWindow.GetWindow<GPGSInstructionWindow>(
-                utility: true,
-                title: "Building for IOS",
-                focus: true);
+            EditorWindow.GetWindow<GPGSInstructionWindow>(true, "Building for IOS", true);
             #endif
         }
 


### PR DESCRIPTION
Unity was not accepting the way parameters where fed to the function, thus not compiling. Fixed it.
See issue:
https://github.com/playgameservices/play-games-plugin-for-unity/issues/571