### PR TITLE
fix Unity macro to support 5.x

### DIFF
--- a/samples/NearbyDroids/Source/Assets/NearbyDroids/Editor/InitializeTagsAndLayers.cs
+++ b/samples/NearbyDroids/Source/Assets/NearbyDroids/Editor/InitializeTagsAndLayers.cs
@@ -84,7 +84,7 @@ namespace NearbyDroids
 
             CheckTags(tagManager);
 
-            #if UNITY_5_0
+            #if UNITY_5
             CheckLayers(tagManager);
             #else
             Debug.LogError("WARNING!! You are using an older version of Unity, " +

--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSPostBuild.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSPostBuild.cs
@@ -35,7 +35,7 @@ namespace GooglePlayGames
         [PostProcessBuild]
         public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
         {
-#if UNITY_5_0
+#if UNITY_5
             if (target != BuildTarget.iOS) {
                 return;
             }


### PR DESCRIPTION
Unity5.1.x not contain UNITY_5_0 macro, but precomposed UNITY_5 macro.