### PR TITLE
iOS compatibility fix with push notification SDKs

### DIFF
--- a/source/PluginDev/Assets/Plugins/iOS/GPGSAppController.mm
+++ b/source/PluginDev/Assets/Plugins/iOS/GPGSAppController.mm
@@ -63,25 +63,33 @@
 
 - (void)application:(UIApplication *)application
             didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-
+ 
+    [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+   
     NSLog(@"Got Token for APNS: %@", deviceToken);
 
+ 
     // send the token to GPGS server so invitations can be sent to the local player
     // NOTE: false indicates this is using the production APNS service.  true indicates
     // that the sandbox service should be used.  This value needs to match the cooresponding
     // certificate registered in the play app console, under linked apps > ios in
-    // the section for push notifications.
     gpg::RegisterDeviceToken(deviceToken, false);
 }
 
 - (void)application:(UIApplication *)application
         didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+   
+    [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
+   
     NSLog(@"Error registering for remote notifications! %@", error);
 }
 
 
 - (void)application:(UIApplication *)application
         didReceiveRemoteNotification:(NSDictionary *)userInfo {
+   
+    [super application:application didReceiveRemoteNotification:userInfo];
+   
     // this returns a bool if it was handled (here you might pass off to another
     // company's sdk for example).
     NSLog(@"Received notification: %@", userInfo);


### PR DESCRIPTION
Google Play Games plugin for Unity is interfering with iOS push notification events. This includes the following selectors:

```objective-c
application:didRegisterForRemoteNotificationsWithDeviceToken:
application:didFailToRegisterForRemoteNotificationsWithError:
application:didReceiveRemoteNotification:
```

Since the super selectors are not being called from GPGSAppController.mm it is creating issues with Push Notification SDKs. This pull request has been tested with OneSignal and it fixes subscription issues. Please merge so this fix can be included in your next release.

Thanks.