### PR TITLE
Remove ios symbols from android compilation.

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSPostBuild.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSPostBuild.cs
@@ -64,6 +64,7 @@ namespace GooglePlayGames
             }
 #endif
 
+#if UNITY_IOS
             #if NO_GPGS
 
             string[] filesToRemove = {
@@ -93,7 +94,7 @@ namespace GooglePlayGames
 
             File.WriteAllText(pbxprojPath, proj.WriteToString());
 
-            #elif UNITY_IOS
+            #else
 
             if (!GPGSProjectSettings.Instance.GetBool(GPGSUtil.IOSSETUPDONEKEY, false))
             {
@@ -131,6 +132,7 @@ namespace GooglePlayGames
             UpdateGeneratedPbxproj(pathToBuiltProject + "/Unity-iPhone.xcodeproj/project.pbxproj");
 
         #endif
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Currently the `GPGSPostBuild.cs` file will give errors at line 81 when targeting android due to `PBXProject` being referenced. 

This PR changes the conditional compilation so that `PBXProject` is only referenced when `UNITY_IOS` is defined.