### PR TITLE
Specify that we are using the GooglePlayGames.OurUtils.Logger class

### DIFF
--- a/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/PlayGamesPlatformTest.cs
+++ b/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/PlayGamesPlatformTest.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 using GooglePlayGames.BasicApi;
 using GooglePlayGames.BasicApi.Multiplayer;
 using GooglePlayGames.OurUtils;
+using Logger = GooglePlayGames.OurUtils.Logger;
 
 namespace GooglePlayGames.UnitTests {
     [TestFixture]

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -20,6 +20,7 @@ namespace GooglePlayGames.BasicApi
     using GooglePlayGames.BasicApi.Multiplayer;
     using GooglePlayGames.OurUtils;
     using UnityEngine.SocialPlatforms;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     public class DummyClient : IPlayGamesClient
     {

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/Multiplayer/TurnBasedMatch.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/Multiplayer/TurnBasedMatch.cs
@@ -20,6 +20,7 @@ namespace GooglePlayGames.BasicApi.Multiplayer
     using System.Collections.Generic;
     using System.Linq;
     using GooglePlayGames.OurUtils;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     /// <summary>
     /// Represents a turn-based match.

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/Nearby/ConnectionRequest.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/Nearby/ConnectionRequest.cs
@@ -17,6 +17,7 @@
 namespace GooglePlayGames.BasicApi.Nearby
 {
     using GooglePlayGames.OurUtils;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     public struct ConnectionRequest
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeNearbyConnectionsClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeNearbyConnectionsClient.cs
@@ -28,6 +28,7 @@ namespace GooglePlayGames.Native
     using GooglePlayGames.Native.PInvoke;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NativeNearbyConnectionsClient : INearbyConnectionClient
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeQuestClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeQuestClient.cs
@@ -25,8 +25,9 @@ namespace GooglePlayGames.Native
     using GooglePlayGames.OurUtils;
     using GooglePlayGames.BasicApi.Quests;
     using GooglePlayGames.Native.PInvoke;
-using Types = GooglePlayGames.Native.Cwrapper.Types;
+    using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NativeQuestClient : IQuestsClient
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeRealtimeMultiplayerClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeRealtimeMultiplayerClient.cs
@@ -26,6 +26,7 @@ namespace GooglePlayGames.Native
     using GooglePlayGames.Native.PInvoke;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     public class NativeRealtimeMultiplayerClient : IRealTimeMultiplayerClient
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeSavedGameClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeSavedGameClient.cs
@@ -28,6 +28,7 @@ namespace GooglePlayGames.Native
     using GooglePlayGames.Native.PInvoke;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NativeSavedGameClient : ISavedGameClient
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeTurnBasedMultiplayerClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeTurnBasedMultiplayerClient.cs
@@ -25,6 +25,7 @@ namespace GooglePlayGames.Native
     using GooglePlayGames.Native.PInvoke;
     using GooglePlayGames.OurUtils;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     public class NativeTurnBasedMultiplayerClient : ITurnBasedMultiplayerClient
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/Callbacks.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/Callbacks.cs
@@ -23,6 +23,7 @@ namespace GooglePlayGames.Native.PInvoke
     using System.Runtime.InteropServices;
     using GooglePlayGames.Native.Cwrapper;
     using GooglePlayGames.OurUtils;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     static class Callbacks
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/GameServicesBuilder.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/GameServicesBuilder.cs
@@ -24,6 +24,7 @@ namespace GooglePlayGames.Native.PInvoke
     using GooglePlayGames.Native.Cwrapper;
     using C = GooglePlayGames.Native.Cwrapper.Builder;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class GameServicesBuilder : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/LeaderboardManager.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/LeaderboardManager.cs
@@ -26,6 +26,7 @@ namespace GooglePlayGames.Native.PInvoke
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
     using UnityEngine.SocialPlatforms;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class LeaderboardManager
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/MultiplayerInvitation.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/MultiplayerInvitation.cs
@@ -25,6 +25,7 @@ namespace GooglePlayGames.Native.PInvoke
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
     using GooglePlayGames.BasicApi.Multiplayer;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class MultiplayerInvitation : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeEndpointDiscoveryListenerHelper.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeEndpointDiscoveryListenerHelper.cs
@@ -24,6 +24,7 @@ namespace GooglePlayGames.Native.PInvoke
     using System.Runtime.InteropServices;
     using C = GooglePlayGames.Native.Cwrapper.EndpointDiscoveryListenerHelper;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NativeEndpointDiscoveryListenerHelper : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeMessageListenerHelper.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeMessageListenerHelper.cs
@@ -24,6 +24,7 @@ namespace GooglePlayGames.Native.PInvoke
     using System.Runtime.InteropServices;
     using C = GooglePlayGames.Native.Cwrapper.MessageListenerHelper;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NativeMessageListenerHelper : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeTurnBasedMatch.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeTurnBasedMatch.cs
@@ -27,6 +27,7 @@ namespace GooglePlayGames.Native.PInvoke
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
     using TBM = GooglePlayGames.BasicApi.Multiplayer.TurnBasedMatch;
     using GooglePlayGames.BasicApi.Multiplayer;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NativeTurnBasedMatch : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NearbyConnectionsManagerBuilder.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NearbyConnectionsManagerBuilder.cs
@@ -26,6 +26,7 @@ namespace GooglePlayGames.Native.PInvoke
     using N = GooglePlayGames.Native.Cwrapper.NearbyConnectionTypes;
     using S = GooglePlayGames.Native.Cwrapper.NearbyConnectionsStatus;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class NearbyConnectionsManagerBuilder : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/RealTimeEventListenerHelper.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/RealTimeEventListenerHelper.cs
@@ -24,6 +24,7 @@ namespace GooglePlayGames.Native.PInvoke
     using C = GooglePlayGames.Native.Cwrapper.RealTimeEventListenerHelper;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class RealTimeEventListenerHelper : BaseReferenceHolder
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/RealtimeManager.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/RealtimeManager.cs
@@ -29,6 +29,7 @@ namespace GooglePlayGames.Native.PInvoke
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
     using MultiplayerStatus = GooglePlayGames.Native.Cwrapper.CommonErrorStatus.MultiplayerStatus;
     using System.Runtime.InteropServices;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class RealtimeManager
     {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/TurnBasedManager.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/TurnBasedManager.cs
@@ -26,6 +26,7 @@ namespace GooglePlayGames.Native.PInvoke
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
     using MultiplayerStatus = GooglePlayGames.Native.Cwrapper.CommonErrorStatus.MultiplayerStatus;
+    using Logger = GooglePlayGames.OurUtils.Logger;
 
     internal class TurnBasedManager
     {


### PR DESCRIPTION
Unity 5.3 introduces a new class called UnityEngine.Logger which collides with the GooglePlayGames.OurUtils.Logger class.

I saw that in about half the cases the full namespace is included inline, but this approach seemed like the least impact on the code. I realize that it is inconsistent but I didn't want to go making lots of changes that aren't necessary. Let me know if you prefer consistency and I'll change it so that either one of the approaches is used everywhere.