### PR TITLE
Change GetIdToken api to be asynchronous 

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -49,10 +49,10 @@ namespace GooglePlayGames.BasicApi
             return "DummyAccessToken";
         }
 
-        public string GetIdToken()
+        public void GetIdToken(Action<string> idTokenCallback)
         {
             LogUsage();
-            return "DummyIdToken";
+            idTokenCallback("DummyIdToken");
         }
 
         public string GetUserId()

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -95,18 +95,18 @@ namespace GooglePlayGames.BasicApi
     string GetUserDisplayName();
 
     /// <summary>
-    /// Gets an access token.
+    /// Returns an id token, which can be verified server side, if they are logged in.
     /// </summary>
     /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
     /// on failure. </param>
     void GetIdToken(Action<string> idTokenCallback);
         
     /// <summary>
-    /// Returns an id token, which can be verified server side, if they are logged in.
+    /// Gets an access token.
     /// </summary>
     /// <returns>An it token. <code>null</code> if they are not logged
     /// in</returns>
-    string GetIdToken();
+    string GetAccessToken();
 
     /// <summary>
     /// Gets the user email.

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -95,12 +95,12 @@ namespace GooglePlayGames.BasicApi
     string GetUserDisplayName();
 
     /// <summary>
-    /// Returns an access token.
+    /// Gets an access token.
     /// </summary>
-    /// <returns>An access token. <code>null</code> if they are not logged
-    /// in</returns>
-    string GetAccessToken();
-
+    /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
+    /// on failure. </param>
+    void GetIdToken(Action<string> idTokenCallback);
+        
     /// <summary>
     /// Returns an id token, which can be verified server side, if they are logged in.
     /// </summary>

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesLocalUser.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesLocalUser.cs
@@ -75,6 +75,17 @@ namespace GooglePlayGames
                 return mPlatform.GetFriends();
             }
         }
+        
+        /// <summary>
+        /// Gets an id token for the user.
+        /// NOTE: This property can only be accessed using the main Unity thread.
+        /// </summary>
+        /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
+        /// on failure. </param>
+        public void GetIdToken(Action<string> idTokenCallback)
+        {
+            authenticated ? mPlatform.GetIdToken(idTokenCallback) : idTokenCallback(null);  
+        }
 
         /// <summary>
         /// Returns whether or not the local user is authenticated to Google Play Games.
@@ -144,21 +155,6 @@ namespace GooglePlayGames
                     }
                 }
                 return retval;
-            }
-        }
-
-        /// <summary>
-        /// Gets an id token for the user.
-        /// NOTE: This property can only be accessed using the main Unity thread.
-        /// </summary>
-        /// <returns>
-        /// An id token for the user.
-        /// </returns>
-        public string idToken
-        {
-            get
-            {
-                return authenticated ? mPlatform.GetIdToken() : string.Empty;
             }
         }
 

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesLocalUser.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesLocalUser.cs
@@ -84,7 +84,10 @@ namespace GooglePlayGames
         /// on failure. </param>
         public void GetIdToken(Action<string> idTokenCallback)
         {
-            authenticated ? mPlatform.GetIdToken(idTokenCallback) : idTokenCallback(null);  
+            if(authenticated) 
+                mPlatform.GetIdToken(idTokenCallback);
+            else
+                idTokenCallback(null);  
         }
 
         /// <summary>

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -374,19 +374,16 @@ namespace GooglePlayGames
         }
 
         /// <summary>
-        /// Returns an id token for the user.
+        /// Get an id token for the user.
         /// </summary>
-        /// <returns>
-        /// An id token for the user.
-        /// </returns>
-        public string GetIdToken()
+        /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
+        /// on failure. </param>
+        public void GetIdToken(Action<string> idTokenCallback)
         {
             if (mClient != null)
             {
-                return mClient.GetIdToken();
-            }
-
-            return null;
+                mClient.GetIdToken(idTokenCallback);
+            }            
         }
 
         /// <summary>

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
@@ -254,6 +254,10 @@ namespace GooglePlayGames.Android
                     });
                 }
             }
+            else
+            {
+                idTokenCallback(idToken);
+            }
         }
     }
 

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
@@ -236,7 +236,7 @@ namespace GooglePlayGames.Android
         /// on failure. </param>
         public void GetIdToken(string serverClientId, Action<string> idTokenCallback)
         {
-            string newScope = "audience:server:client_id:" + serverClientID;
+            string newScope = "audience:server:client_id:" + serverClientId;
             if (string.IsNullOrEmpty(idToken) || (newScope != idTokenScope))
             {
                 if (!fetchingIdToken)
@@ -251,7 +251,7 @@ namespace GooglePlayGames.Android
                         
                         if(!ok) idTokenCb(null);
                         idTokenCb = null;
-                    };
+                    });
                 }
             }
         }

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
@@ -37,8 +37,9 @@ namespace GooglePlayGames.Android
         private string accessToken;
         private string idToken;
         private string idTokenScope;
+        private Action<string> idTokenCb;
         private string rationale;
-
+        
         public static AndroidJavaObject GetActivity()
         {
             using (var jc = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
@@ -126,6 +127,7 @@ namespace GooglePlayGames.Android
                         if (fetchIdToken && !string.IsNullOrEmpty(id))
                         {
                             idToken = id;
+                            idTokenCb(idToken);
                         }
                         if (fetchEmail && !string.IsNullOrEmpty(email))
                         {
@@ -227,24 +229,31 @@ namespace GooglePlayGames.Android
             return accessToken;
         }
 
-        /// <summary>Gets the OpenID Connect ID token for authentication with a server backend.</summary>
-        /// <returns>The OpenID Connect ID token.</returns>
+        /// <summary>Gets the OpenID Connect ID token for authentication with a server backend.</summary>        
         /// <param name="serverClientID">Server client ID from console.developers.google.com or the Play Games
         /// services console.</param>
-        public string GetIdToken(string serverClientID)
+        /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
+        /// on failure. </param>
+        public void GetIdToken(string serverClientId, Action<string> idTokenCallback)
         {
             string newScope = "audience:server:client_id:" + serverClientID;
             if (string.IsNullOrEmpty(idToken) || (newScope != idTokenScope))
             {
                 if (!fetchingIdToken)
                 {
+                    
                     fetchingIdToken = true;
                     idTokenScope = newScope;
-                    Fetch(idTokenScope, rationale, false, false, true, (ok) => fetchingIdToken = false);
+                    idTokenCb = idTokenCallback;
+                    
+                    Fetch(idTokenScope, rationale, false, false, true, (ok) => {
+                        fetchingIdToken = false;
+                        
+                        if(!ok) idTokenCb(null);
+                        idTokenCb = null;
+                    };
                 }
             }
-
-            return idToken;
         }
     }
 

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/IOS/IOSTokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/IOS/IOSTokenClient.cs
@@ -77,12 +77,21 @@ namespace GooglePlayGames.IOS {
         /// <summary>
         /// Gets the OpenID Connect ID token for authentication with a server backend.
         /// </summary>
-        /// <returns>The OpenID Connect ID token.</returns>
+        /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
+        /// on failure. </param>
         /// <param name="serverClientID">Server client ID from console.developers.google.com or the Play Games
         /// services console.</param>
-        public string GetIdToken(string serverClientID)
+        public void GetIdToken(string serverClientID, Action<string> idTokenCallback)
         {
-            return _GooglePlayGetIdToken();
+            var token =  _GooglePlayGetIdToken();
+            if(String.IsNullOrEmpty(token))
+            {
+                idTokenCallback(null);
+            }
+            else
+            {
+                idTokenCallback(token);
+            }
         }
     }
 }

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -319,7 +319,7 @@ namespace GooglePlayGames.Native
             }
             mTokenClient.SetRationale(rationale);
             
-            idTokenCallback(mTokenClient.GetIdToken(GameInfo.WebClientId));
+            mTokenClient.GetIdToken(GameInfo.WebClientId,idTokenCallback);
         }
 
         ///<summary></summary>

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -295,13 +295,15 @@ namespace GooglePlayGames.Native
         /// <summary>
         /// Returns an id token, which can be verified server side, if they are logged in.
         /// </summary>
+        /// <param name="idTokenCallback"> A callback to be invoked after token is retrieved. Will be passed null value
+        /// on failure. </param>
         /// <returns>The identifier token.</returns>
-        public string GetIdToken()
+        public void GetIdToken(Action<string> idTokenCallback)
         {
             if (!this.IsAuthenticated())
             {
                 Debug.Log("Cannot get API client - not authenticated");
-                return null;
+                idTokenCallback(null);
             }
 
             if(!GameInfo.WebClientIdInitialized())
@@ -313,10 +315,11 @@ namespace GooglePlayGames.Native
                     // avoid int overflow
                     noWebClientIdWarningCount = (noWebClientIdWarningCount/ webclientWarningFreq) + 1;
                 }
-                return null;
+                idTokenCallback(null);
             }
             mTokenClient.SetRationale(rationale);
-            return mTokenClient.GetIdToken(GameInfo.WebClientId);
+            
+            idTokenCallback(mTokenClient.GetIdToken(GameInfo.WebClientId));
         }
 
         ///<summary></summary>

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/TokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/TokenClient.cs
@@ -23,7 +23,7 @@ namespace GooglePlayGames
 
         string GetAccessToken();
         string GetAuthorizationCode(string serverClientId);
-        string GetIdToken(string serverClientId);
+        void GetIdToken(string serverClientId, Action<string> idTokenCallback);
         void SetRationale(string rationale);
     }
 }

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/TokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/TokenClient.cs
@@ -13,6 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // </copyright>
+using System;
 
 #if (UNITY_ANDROID || (UNITY_IPHONE && !NO_GPGS))
 namespace GooglePlayGames


### PR DESCRIPTION
Following from #865, this pull request changes the `GetIdToken` api to be callback based due to the underlying nature of the id token being retrieved via network call. This is needed in order to reliably retrieve the token and validate the identity of a user via GPGS on an external server.