### PR TITLE
Fix Null Exception on Unity 5.3.3 when Sending Invitation to RTMP match in example.

### DIFF
--- a/samples/QuizRacer/Source/Assets/QuizRacer/MenuPanels/MainMenuEvents.cs
+++ b/samples/QuizRacer/Source/Assets/QuizRacer/MenuPanels/MainMenuEvents.cs
@@ -151,16 +151,16 @@ namespace QuizRacer.MenuPanels
                 txt.text = msg;
                 if (error)
                 {
-                    Color c = statusText.GetComponent<Image>().color;
+                    Color c = statusText.GetComponent<Text>().color;
                     c.a = 1.0f;
-                    statusText.GetComponent<Image>().color = c;
+                    statusText.GetComponent<Text>().color = c;
                     mStatusCountdown = ERROR_STATUS_TIMEOUT;
                 }
                 else
                 {
-                    Color c = statusText.GetComponent<Image>().color;
+                    Color c = statusText.GetComponent<Text>().color;
                     c.a = 0.0f;
-                    statusText.GetComponent<Image>().color = c;
+                    statusText.GetComponent<Text>().color = c;
                     mStatusCountdown = INFO_STATUS_TIMEOUT;
                 }
             }


### PR DESCRIPTION
there is no image component on these gameobjects, so it was causing the script to fail to show the status.