### PR TITLE
Fix NullReferenceException on null callback

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -1120,7 +1120,10 @@ namespace GooglePlayGames
             if (!IsAuthenticated())
             {
                 GooglePlayGames.OurUtils.Logger.e("ShowLeaderboardUI can only be called after authentication.");
-                callback(UIStatus.NotAuthorized);
+                if (callback != null)
+                {
+                    callback(UIStatus.NotAuthorized);
+                }
                 return;
             }
 


### PR DESCRIPTION
Null callback is common because the ShowLeaderboardUI() method always invokes with a null callback.

See https://github.com/playgameservices/play-games-plugin-for-unity/blob/master/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs#L1072 for common cause.