### PR TITLE
Fix null achievement array

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -829,7 +829,11 @@ namespace GooglePlayGames
             {
                 GooglePlayGames.OurUtils.Logger.e(
                     "LoadAchievementDescriptions can only be called after authentication.");
-                callback.Invoke(null);
+                if (callback != null)
+                {
+                    callback.Invoke(null);
+                }
+                return;
             }
 
             mClient.LoadAchievements(ach =>


### PR DESCRIPTION
Need to return if not authenticated, otherwise `mClient.LoadAchievements` will fail with a null achievement array.

Also added a null guard around the callback invocation.

Full error:

```
NullReferenceException: Object reference not set to an instance of an object
GooglePlayGames.PlayGamesPlatform+<LoadAchievements>c__AnonStorey9.<>m__5 (GooglePlayGames.BasicApi.Achievement[] ach)
GooglePlayGames.BasicApi.DummyClient.LoadAchievements (System.Action`1 callback)
GooglePlayGames.PlayGamesPlatform.LoadAchievements (System.Action`1 callback)
UnityEngine.Social.LoadAchievements (System.Action`1 callback)
```