### PR TITLE
Update GPGSAndroidSetupUI.cs

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSAndroidSetupUI.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSAndroidSetupUI.cs
@@ -203,8 +203,8 @@ namespace GooglePlayGames.Editor
         public void OnEnable()
         {
             GPGSProjectSettings settings = GPGSProjectSettings.Instance;
-            mConstantDirectory = settings.Get("ConstDir", mConstantDirectory);
-            mClassName = settings.Get(GPGSUtil.CLASSNAMEKEY);
+            mConstantDirectory = settings.Get(GPGSUtil.CLASSDIRECTORYKEY, mConstantDirectory);
+            mClassName = settings.Get(GPGSUtil.CLASSNAMEKEY, mClassName);
             mConfigData = settings.Get(GPGSUtil.ANDROIDRESOURCEKEY);
             mWebClientId = settings.Get(GPGSUtil.WEBCLIENTIDKEY);
             mRequiresGooglePlus = settings.GetBool(GPGSUtil.REQUIREGOOGLEPLUSKEY, false);


### PR DESCRIPTION
1) Changed the hard-coded dictionary key "ConstDir" which is always returning the default value "Assets". It seems like that key is no longer present in GPGSUtil.

2) Added the default value for mClassName which is "GPGSIds".