### PR TITLE
Use Oauth scopes from PlayGamesClientConfguration

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -195,6 +195,10 @@ namespace GooglePlayGames.Native
                         {
                             builder.RequireGooglePlus();
                         }
+                        string[] scopes = mConfiguration.Scopes;
+                        for (int i = 0; i < scopes.Length; i++) {
+                            builder.AddOauthScope(scopes[i]);
+                        }
                         Debug.Log("Building GPG services, implicitly attempts silent auth");
                         mAuthState = AuthState.SilentPending;
                         mServices = builder.Build(config);


### PR DESCRIPTION
I addded PlayGamesClientConfiguration addOauthScope function to request scopes from user.

From issue #1293