### PR TITLE
Add Oauth Scopes to PlayGamesClientConfiguration

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/PlayGamesClientConfiguration.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/PlayGamesClientConfiguration.cs
@@ -204,7 +204,7 @@ namespace GooglePlayGames.BasicApi
                 mEnableSaveGames = true;
                 return this;
             }
-            
+
             /// <summary>
             /// Requests use of the player's Google+ social graph.
             /// </summary>
@@ -293,7 +293,7 @@ namespace GooglePlayGames.BasicApi
             {
                 return mEnableSaveGames;
             }
-            
+
             /// <summary>
             /// Determines whether this instance has Google+ required.
             /// </summary>

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/PlayGamesClientConfiguration.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/PlayGamesClientConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PlayGamesClientConfiguration.cs" company="Google Inc.">
+// <copyright file="PlayGamesClientConfiguration.cs" company="Google Inc.">
 // Copyright (C) 2014 Google Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ namespace GooglePlayGames.BasicApi
 {
     using GooglePlayGames.BasicApi.Multiplayer;
     using GooglePlayGames.OurUtils;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Provides configuration for <see cref="PlayGamesPlatform"/>. If you wish to use either Saved
@@ -44,6 +45,11 @@ namespace GooglePlayGames.BasicApi
         /// Flag indicating to request use of a player's Google+ social graph.
         /// </summary>
         private readonly bool mRequireGooglePlus;
+        
+        /// <summary>
+        /// Array of scopes to be requested from user. None is considered as 'games_lite'.
+        /// </summary>
+        private readonly string[] mScopes;
 
         /// <summary>
         /// The invitation delegate.
@@ -72,6 +78,7 @@ namespace GooglePlayGames.BasicApi
             this.mMatchDelegate = builder.GetMatchDelegate();
             this.mPermissionRationale = builder.GetPermissionRationale();
             this.mRequireGooglePlus = builder.HasRequireGooglePlus();
+            this.mScopes = builder.getScopes();
         }
 
         /// <summary>
@@ -97,6 +104,18 @@ namespace GooglePlayGames.BasicApi
             get
             {
                 return mRequireGooglePlus;
+            }
+        }
+        
+        /// <summary>
+        /// Gets a array of scopes to be requested from the user.
+        /// </summary>
+        /// <value>String array of scopes.</value>
+        public string[] Scopes
+        {
+            get
+            {
+                return mScopes;
             }
         }
 
@@ -150,6 +169,11 @@ namespace GooglePlayGames.BasicApi
             /// The flag to request Google+. Default is false.
             /// </summary>
             private bool mRequireGooglePlus = false;
+            
+            /// <summary>
+            /// The scopes to request from the user. Default is none.
+            /// </summary>
+            private List<string> mScopes = null;
 
             /// <summary>
             /// The invitation delegate.  Default is a no-op;
@@ -180,7 +204,7 @@ namespace GooglePlayGames.BasicApi
                 mEnableSaveGames = true;
                 return this;
             }
-
+            
             /// <summary>
             /// Requests use of the player's Google+ social graph.
             /// </summary>
@@ -193,6 +217,24 @@ namespace GooglePlayGames.BasicApi
             public Builder RequireGooglePlus()
             {
                 mRequireGooglePlus = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Requests an Oauth scope from the user.
+            /// </summary>
+            /// <remarks>
+            /// Not setting one will default to 'games_lite' and will not show a consent
+            /// dialog to the user. Valid examples are 'profile' and 'email'.
+            /// Full list: https://developers.google.com/identity/protocols/googlescopes
+            /// To exchange the auth code with an id_token (or user id) on your server, 
+            /// you must add at least one scope.
+            /// </remarks>
+            /// <returns>The builder.</returns>
+            public Builder AddOauthScope(string scope)
+            {
+                if (mScopes == null) mScopes = new List<string>();
+                mScopes.Add(scope);
                 return this;
             }
 
@@ -251,7 +293,7 @@ namespace GooglePlayGames.BasicApi
             {
                 return mEnableSaveGames;
             }
-
+            
             /// <summary>
             /// Determines whether this instance has Google+ required.
             /// </summary>
@@ -259,6 +301,14 @@ namespace GooglePlayGames.BasicApi
             internal bool HasRequireGooglePlus()
             {
                 return mRequireGooglePlus;
+            }
+
+            /// <summary>
+            /// Gets the Oauth scopes to be requested from the user.
+            /// </summary>
+            /// <returns>String array of scopes.</returns>
+            internal string[] getScopes() {
+                return mScopes == null? new string[0] : mScopes.ToArray();
             }
 
             /// <summary>


### PR DESCRIPTION
Adds option to add Oauth scopes to be requested by user, like 'profile' and 'email'. Not adding scopes will not allow server to exchange auth code with id_token. I will also update Platforms/Native/NativeClient.cs

from issue #1293