### PR TITLE
Reset image on ResetIdentity

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesUserProfile.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesUserProfile.cs
@@ -52,7 +52,11 @@ namespace GooglePlayGames
         {
             mDisplayName = displayName;
             mPlayerId = playerId;
-            mAvatarUrl = avatarUrl;
+            if (mAvatarUrl != avatarUrl)
+            {
+                mImage = null;
+                mAvatarUrl = avatarUrl;
+            }
             mImageLoading = false;
         }
 


### PR DESCRIPTION
The profile image does not change on ResetIdentity();
My proposed change is that since mAvatarUrl is being reset, the mImage should be reset too.