### PR TITLE
Added metaData property to PlayGamesScore class

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesScore.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesScore.cs
@@ -133,6 +133,20 @@ namespace GooglePlayGames
                 return (int)mRank;
             }
         }
+
+		/// <summary>
+		/// Gets the metaData (scoreTag).
+		/// </summary>
+		/// <returns>
+		/// The metaData.
+		/// </returns>
+		public string metaData
+		{
+			get 
+			{
+				return mMetadata;
+			}
+		}
     }
 }
 #endif

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesScore.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesScore.cs
@@ -134,19 +134,19 @@ namespace GooglePlayGames
             }
         }
 
-		/// <summary>
-		/// Gets the metaData (scoreTag).
-		/// </summary>
-		/// <returns>
-		/// The metaData.
-		/// </returns>
-		public string metaData
-		{
-			get 
-			{
-				return mMetadata;
-			}
-		}
+        /// <summary>
+        /// Gets the metaData (scoreTag).
+        /// </summary>
+        /// <returns>
+        /// The metaData.
+        /// </returns>
+        public string metaData
+        {
+            get 
+            {
+                return mMetadata;
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
As per issue #1518, a property (metaData) was added to the PlayGamesScore class to provide access to the private field mMetadata. With the change, the metaData string for a particular leaderboard score can be loaded. I tested this change with a Unity project, submitting a 64-character string to a Google Play leaderboard using the appropriate ReportScores overload and subsequently retrieved the string with a LoadScores call.