### PR TITLE
Ability to reload the setting by code

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSProjectSettings.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSProjectSettings.cs
@@ -174,6 +174,11 @@ namespace GooglePlayGames.Editor
             wr.Close();
             mDirty = false;
         }
+        
+        public static void Reload ()
+	    {
+		    sInstance = new GPGSProjectSettings();
+	    }
     }
 }
 #endif


### PR DESCRIPTION
**Motivation:** Some projects like mine uses different app ids and bundle ids for different environment distributions (ci, staging, production). In previous version of the plugin the class was not using a singleton and would reload when necessary.

**Proposed change:** Add a static reload function. The function will simply replace the current static instance by a new one.

**Possible improvements:** Move the logic inside the constructor to a public Load function and avoid the static instance replacement, but allowing the data stored in the dictionary to be refreshed / replaced.