### PR TITLE
Added namespace to PlayerStats reference in IClientImpl

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/IClientImpl.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/IClientImpl.cs
@@ -31,7 +31,7 @@ namespace GooglePlayGames
 
         TokenClient CreateTokenClient (string playerId, bool reset);
 
-        void GetPlayerStats(IntPtr apiClientPtr, Action<CommonStatusCodes, PlayerStats> callback);
+        void GetPlayerStats(IntPtr apiClientPtr, Action<CommonStatusCodes, GooglePlayGames.BasicApi.PlayerStats> callback);
     }
 }
 


### PR DESCRIPTION
If the client application has a class named PlayerStats, GPGS does not compile due to an ambiguous type in IClientImpl. Also, the error message is misleading- it takes the user to AndroidClient.cs.

The issue is discussed here:
https://github.com/playgameservices/play-games-plugin-for-unity/issues/1198