### PR TITLE
Tips for fixing GIDSignIn.h file missing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,9 +1054,9 @@ Select **DWARF** instead of **DWARF with dSYM**.
 to the framework in the Pods project, then add it back.  This is a resolution for
 missing other frameworks as well.
 
-**GIDSignIn.h file not found**.  Make sure you are:
+**GIDSignIn.h file not found**.  Make sure:
 
-1. Opening the .xcworkspace file.
+1. You open the .xcworkspace file.
 2. OTHER_LDFLAGS in build settings include $(inherited)
 3. HEADER_SEARCH_PATHS in build settings include $(inherited)
 4. OTHER_CFLAGS in build settings include $(inherited)

--- a/README.md
+++ b/README.md
@@ -1055,14 +1055,13 @@ to the framework in the Pods project, then add it back.  This is a resolution fo
 missing other frameworks as well.
 
 **GIDSignIn.h file not found**.  Make sure you are:
-```
-# Opening the .xcworkspace file.
-# OTHER_LDFLAGS in build settings include $(inherited)
-# HEADER_SEARCH_PATHS in build settings include $(inherited)
-# OTHER_CFLAGS in build settings include $(inherited)
-# ENABLE_BITCODE in build settings is set to NO
-# Libraries/Plugins/iOS/GPGSAppController.mm (or Libraries/GPGSAppController.mm) has compiler flags that include -fobjc-arc
-```
+
+1. Opening the .xcworkspace file.
+2. OTHER_LDFLAGS in build settings include $(inherited)
+3. HEADER_SEARCH_PATHS in build settings include $(inherited)
+4. OTHER_CFLAGS in build settings include $(inherited)
+5. ENABLE_BITCODE in build settings is set to NO
+6. Libraries/Plugins/iOS/GPGSAppController.mm (or Libraries/GPGSAppController.mm) has compiler flags that include -fobjc-arc
 
 ## Building for iOS to run on the simulator (pre-Unity 5.0)
 

--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,16 @@ Select **DWARF** instead of **DWARF with dSYM**.
 to the framework in the Pods project, then add it back.  This is a resolution for
 missing other frameworks as well.
 
+**GIDSignIn.h file not found**.  Make sure you are:
+```
+# Opening the .xcworkspace file.
+# OTHER_LDFLAGS in build settings include $(inherited)
+# HEADER_SEARCH_PATHS in build settings include $(inherited)
+# OTHER_CFLAGS in build settings include $(inherited)
+# ENABLE_BITCODE in build settings is set to NO
+# Libraries/Plugins/iOS/GPGSAppController.mm (or Libraries/GPGSAppController.mm) has compiler flags that include -fobjc-arc
+```
+
 ## Building for iOS to run on the simulator (pre-Unity 5.0)
 
 **Note:** If you are using Unity 5.0 or greater, no changes to the generated project

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/IClientImpl.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/IClientImpl.cs
@@ -31,7 +31,7 @@ namespace GooglePlayGames
 
         TokenClient CreateTokenClient (string playerId, bool reset);
 
-        void GetPlayerStats(IntPtr apiClientPtr, Action<CommonStatusCodes, PlayerStats> callback);
+        void GetPlayerStats(IntPtr apiClientPtr, Action<CommonStatusCodes, GooglePlayGames.BasicApi.PlayerStats> callback);
     }
 }
 


### PR DESCRIPTION
Added the tips from @claywilkinson to the iOS trouble shooting part of the documentation.