### PR TITLE
Adding support to call Games.setGravityForPopups() to the plugin.

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/CommonTypes.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/CommonTypes.cs
@@ -151,7 +151,16 @@ namespace GooglePlayGames.BasicApi
         Dismissed = 4
       }
 
-    public class CommonTypesUtil {
+      public enum Gravity
+      {
+        TOP = 48,
+        BOTTOM = 80,
+        LEFT = 3,
+        RIGHT = 5,
+        CENTER_HORIZONTAL = 1
+       }
+
+	public class CommonTypesUtil {
         public static bool StatusIsSuccess(ResponseStatus status)
         {
             return ((int)status) > 0;

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -499,6 +499,16 @@ namespace GooglePlayGames.BasicApi
         }
 
         /// <summary>
+        /// Sets the gravity for popups (Android only).
+        /// </summary>
+        /// <remarks>This can only be called after authentication.  It affects
+        /// popups for achievements and other game services elements.</remarks>
+        /// <param name="gravity">Gravity for the popup.</param>
+        public void SetGravityForPopups(Gravity gravity) {
+            LogUsage();
+        }
+
+        /// <summary>
         /// Logs the usage.
         /// </summary>
         private static void LogUsage()

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -347,6 +347,14 @@ namespace GooglePlayGames.BasicApi
     /// </summary>
     /// <returns>The API client.</returns>
     IntPtr GetApiClient();
+
+    /// <summary>
+    /// Sets the gravity for popups (Android only).
+    /// </summary>
+    /// <remarks>This can only be called after authentication.  It affects
+    /// popups for achievements and other game services elements.</remarks>
+    /// <param name="gravity">Gravity for the popup.</param>
+    void SetGravityForPopups(Gravity gravity);
   }
 
   /// <summary>

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -311,6 +311,16 @@ namespace GooglePlayGames
         }
 
         /// <summary>
+        /// Sets the gravity for popups (Android only).
+        /// </summary>
+        /// <remarks>This can only be called after authentication.  It affects
+        /// popups for achievements and other game services elements.</remarks>
+        /// <param name="gravity">Gravity for the popup.</param>
+        public void SetGravityForPopups(Gravity gravity) {
+            mClient.SetGravityForPopups(gravity);
+        }
+
+        /// <summary>
         /// Specifies that the ID <c>fromId</c> should be implicitly replaced by <c>toId</c>
         /// on any calls that take a leaderboard or achievement ID.
         /// </summary>

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
@@ -27,7 +27,6 @@ namespace GooglePlayGames.Android
     using C = GooglePlayGames.Native.Cwrapper.InternalHooks;
     using GooglePlayGames.Native.PInvoke;
 
-
     internal class AndroidClient : IClientImpl
     {
         internal const string BridgeActivityClass = "com.google.games.bridge.NativeBridgeActivity";
@@ -186,6 +185,11 @@ namespace GooglePlayGames.Android
                     Games.Stats.loadPlayerStats(client, true);
 
             pr.setResultCallback(resCallback);
+        }
+
+        public void SetGravityForPopups(IntPtr apiClient, Gravity gravity) {
+            GoogleApiClient client = new GoogleApiClient(apiClient);
+            Games.setGravityForPopups(client, (int)gravity | (int)Gravity.CENTER_HORIZONTAL);
         }
 
         class StatsResultCallback : ResultCallbackProxy<Stats_LoadPlayerStatsResultObject>

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/IClientImpl.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/IClientImpl.cs
@@ -32,6 +32,14 @@ namespace GooglePlayGames
         TokenClient CreateTokenClient (bool reset);
 
         void GetPlayerStats(IntPtr apiClientPtr, Action<CommonStatusCodes, GooglePlayGames.BasicApi.PlayerStats> callback);
+
+        /// <summary>
+        /// Sets the gravity for popups (Android only).
+        /// </summary>
+        /// <remarks>This can only be called after authentication.  It affects
+        /// popups for achievements and other game services elements.</remarks>
+        /// <param name="gravity">Gravity for the popup.</param>
+        void SetGravityForPopups(IntPtr apiClient, Gravity gravity);
     }
 }
 

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/IOS/IOSClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/IOS/IOSClient.cs
@@ -73,6 +73,18 @@ namespace GooglePlayGames.IOS
             throw new InvalidOperationException(
                 "The native API should be called for iOS");
         }
+
+        /// <summary>
+        /// Sets the gravity for popups (Android only).
+        /// </summary>
+        /// <remarks>This can only be called after authentication.  It affects
+        /// popups for achievements and other game services elements.</remarks>
+        /// <param name="gravity">Gravity for the popup.</param>
+        public void SetGravityForPopups(IntPtr api, Gravity gravity)
+        {
+            throw new InvalidOperationException(
+                "Not supported on iOS");
+        }
     }
 }
 #endif

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -682,6 +682,13 @@ namespace GooglePlayGames.Native
             return mUser.AvatarURL;
         }
 
+        public void SetGravityForPopups(Gravity gravity)
+        {
+            PlayGamesHelperObject.RunOnGameThread(() => 
+             clientImpl.SetGravityForPopups(GetApiClient(), gravity));
+        }
+
+
         ///<summary></summary>
         /// <seealso cref="GooglePlayGames.BasicApi.IPlayGamesClient.GetPlayerStats"/>
         public void GetPlayerStats(Action<CommonStatusCodes, PlayerStats> callback)


### PR DESCRIPTION
Only works for Android, must be called after successfully authenticating.