### PR TITLE
Reduced Warning log spam in Unity Log or compiler output about Quests being removed in 2018

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -422,6 +422,7 @@ namespace GooglePlayGames.BasicApi
         /// Gets the quests client.
         /// </summary>
         /// <returns>The quests client.</returns>
+        [Obsolete("Quests are being removed in 2018.")]
         public GooglePlayGames.BasicApi.Quests.IQuestsClient GetQuestsClient()
         {
             LogUsage();

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -326,6 +326,7 @@ namespace GooglePlayGames.BasicApi
     /// Gets the quests client.
     /// </summary>
     /// <returns>The quests client.</returns>
+    [Obsolete("Quests are being removed in 2018.")]
     Quests.IQuestsClient GetQuestsClient();
 
     /// <summary>

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/Quests/IQuest.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/Quests/IQuest.cs
@@ -108,6 +108,7 @@ namespace GooglePlayGames.BasicApi.Quests
         /// The current milestone for the quest. This represents the next goal that players should hit
         /// on their way to completing the quest.
         /// </summary>
+        [Obsolete("Quests are being removed in 2018.")]
         IQuestMilestone Milestone
         {
             get;

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -55,6 +55,7 @@ namespace GooglePlayGames.Native
         private volatile NativeRealtimeMultiplayerClient mRealTimeClient;
         private volatile ISavedGameClient mSavedGameClient;
         private volatile IEventsClient mEventsClient;
+        [Obsolete("Quests are being removed in 2018.")]
         private volatile IQuestsClient mQuestsClient;
         private volatile IVideoClient mVideoClient;
         private volatile TokenClient mTokenClient;
@@ -230,7 +231,9 @@ namespace GooglePlayGames.Native
                         mAuthState = AuthState.SilentPending;
                         mServices = builder.Build(config);
                         mEventsClient = new NativeEventClient(new EventManager(mServices));
+#pragma warning disable 0618 // Warning CS0618  'IQuestMilestone' is obsolete: 'Quests are being removed in 2018.'
                         mQuestsClient = new NativeQuestClient(new QuestManager(mServices));
+#pragma warning restore
                         mVideoClient = new NativeVideoClient(new VideoManager(mServices));
                         mTurnBasedClient =
                         new NativeTurnBasedMultiplayerClient(this, new TurnBasedManager(mServices));
@@ -1121,6 +1124,7 @@ namespace GooglePlayGames.Native
 
         ///<summary></summary>
         /// <seealso cref="GooglePlayGames.BasicApi.IPlayGamesClient.GetQuestsClient"/>
+        [Obsolete("Quests are being removed in 2018.")]
         public IQuestsClient GetQuestsClient()
         {
             lock (GameServicesLock)

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeQuestClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeQuestClient.cs
@@ -28,11 +28,13 @@ namespace GooglePlayGames.Native
 using Types = GooglePlayGames.Native.Cwrapper.Types;
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
 
+    [Obsolete("Quests are being removed in 2018.")]
     internal class NativeQuestClient : IQuestsClient
     {
 
         private readonly QuestManager mManager;
 
+        [Obsolete("Quests are being removed in 2018.")]
         internal NativeQuestClient(QuestManager manager)
         {
             this.mManager = Misc.CheckNotNull(manager);

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeQuest.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeQuest.cs
@@ -27,6 +27,7 @@ namespace GooglePlayGames.Native.PInvoke
     internal class NativeQuest : BaseReferenceHolder, IQuest
     {
 
+        [Obsolete("Quests are being removed in 2018.")]
         private volatile NativeQuestMilestone mCachedMilestone;
 
         internal NativeQuest(IntPtr selfPointer)
@@ -110,6 +111,7 @@ namespace GooglePlayGames.Native.PInvoke
             }
         }
 
+        [Obsolete("Quests are being removed in 2018.")]
         public IQuestMilestone Milestone
         {
             get

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeQuestMilestone.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeQuestMilestone.cs
@@ -24,6 +24,7 @@ namespace GooglePlayGames.Native.PInvoke
     using Types = GooglePlayGames.Native.Cwrapper.Types;
     using C = GooglePlayGames.Native.Cwrapper.QuestMilestone;
 
+    [Obsolete("Quests are being removed in 2018.")]
     internal class NativeQuestMilestone : BaseReferenceHolder, IQuestMilestone
     {
         internal NativeQuestMilestone(IntPtr selfPointer)

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/QuestManager.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/QuestManager.cs
@@ -26,10 +26,12 @@ namespace GooglePlayGames.Native.PInvoke
     using Status = GooglePlayGames.Native.Cwrapper.CommonErrorStatus;
     using Types = GooglePlayGames.Native.Cwrapper.Types;
 
+    [Obsolete("Quests are being removed in 2018.")]
     internal class QuestManager
     {
         private readonly GameServices mServices;
 
+        [Obsolete("Quests are being removed in 2018.")]
         internal QuestManager(GameServices services)
         {
             mServices = Misc.CheckNotNull(services);
@@ -111,6 +113,7 @@ namespace GooglePlayGames.Native.PInvoke
                 "QuestManager#AcceptCallback", Callbacks.Type.Temporary, response, data);
         }
 
+        [Obsolete("Quests are being removed in 2018.")]
         internal void ClaimMilestone(NativeQuestMilestone milestone,
                                  Action<ClaimMilestoneResponse> callback)
         {


### PR DESCRIPTION
When deprecating some class or interface, all APIs that expose these things, all ancestors must be also marked as [Obsolete] to create a "deprecation boundary" and propagate warnings about their usage from library itself into its users.
In one place "#pragma warning disable 0618" was needed.