### PR TITLE
Added RevealAchievement method to PlayGamesPlatform

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -751,6 +751,46 @@ namespace GooglePlayGames
         }
 
         /// <summary>
+        /// Reveals the achievement with the passed identifier. This is a Play Games extension of the ISocialPlatform API.
+        /// </summary>
+        /// <remarks>If the operation succeeds, the callback
+        /// will be invoked on the game thread with <code>true</code>. If the operation fails, the
+        /// callback will be invoked with <code>false</code>. This operation will immediately fail if
+        /// the user is not authenticated (i.e. the callback will immediately be invoked with
+        /// <code>false</code>). If the achievement is already in a revealed state, this call will
+        /// succeed immediately.
+        /// </remarks>
+        /// <param name='achievementID'>
+        /// The ID of the achievement to increment. This can be a raw Google Play
+        /// Games achievement ID (alphanumeric string), or an alias that was previously configured
+        /// by a call to <see cref="AddIdMapping" />.
+        /// </param>
+        /// <param name='callback'>
+        /// The callback to call to report the success or failure of the operation. The callback
+        /// will be called with <c>true</c> to indicate success or <c>false</c> for failure.
+        /// </param>
+        public void RevealAchievement(string achievementID, Action<bool> callback = null)
+        {
+            if (!IsAuthenticated())
+            {
+                GooglePlayGames.OurUtils.Logger.e(
+                    "RevealAchievement can only be called after authentication.");
+                if (callback != null)
+                {
+                    callback.Invoke(false);
+                }
+
+                return;
+            }
+
+            // map ID, if it's in the dictionary
+            GooglePlayGames.OurUtils.Logger.d(
+                "RevealAchievement: " + achievementID);
+            achievementID = MapId(achievementID);
+            mClient.RevealAchievement(achievementID, callback);
+        }
+
+        /// <summary>
         /// Unlocks the achievement with the passed identifier. This is a Play Games extension of the ISocialPlatform API.
         /// </summary>
         /// <remarks>If the operation succeeds, the callback
@@ -769,7 +809,7 @@ namespace GooglePlayGames
         /// The callback to call to report the success or failure of the operation. The callback
         /// will be called with <c>true</c> to indicate success or <c>false</c> for failure.
         /// </param>
-        public void UnlockAchievement(string achievementID, Action<bool> callback)
+        public void UnlockAchievement(string achievementID, Action<bool> callback = null)
         {
             if (!IsAuthenticated())
             {


### PR DESCRIPTION
Following up on pull request #1528, I've made the callback parameter on UnlockAchievement optional.

Also similarly to UnlockAchievement, the IPlayGamesClient interface has a nice method for revealing achievements but on PlayGamesPlatform the only way to call this method is through ReportProgress. To fix that inconsistency I've also exposed RevealAchievement method on PlayGamesPlatform.