### PR TITLE
#1909 Account Picker displayed after backgrounding/foregrounding app

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -100,6 +100,15 @@ namespace GooglePlayGames.BasicApi
             return null;
         }
 
+		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+		{
+			LogUsage();
+			if (callback != null)
+			{
+				callback(CommonStatusCodes.ApiNotConnected, "");
+			}
+		}
+
         public void GetAnotherServerAuthCode(bool reAuthenticateIfNeeded,
                                              Action<string> callback)
         {

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -108,7 +108,13 @@ namespace GooglePlayGames.BasicApi
     /// </remarks>
     string GetServerAuthCode();
 
-    /// <summary>
+	/// <summary>
+	/// Retrieves the server auth code for this client.
+	/// </summary>
+	/// <param name="callback">Callback for response.</param>
+	void GetServerAuthCode(Action<CommonStatusCodes, string> callback);
+
+	/// <summary>
     /// Gets another server auth code.
     /// </summary>
     /// <remarks>This method should be called after authenticating, and exchanging

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -541,7 +541,39 @@ namespace GooglePlayGames
             return null;
         }
 
-        /// <summary>
+		/// <summary>
+		/// Gets the server auth code.
+		/// </summary>
+		/// <remarks>This code is used by the server application in order to get
+		/// an oauth token.  For how to use this acccess token please see:
+		/// https://developers.google.com/drive/v2/web/auth/web-server
+		/// </remarks>
+		/// <param name="callback">Callback.</param>
+		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+		{
+			if (mClient != null && mClient.IsAuthenticated())
+			{
+				if (GameInfo.WebClientIdInitialized())
+				{
+					mClient.GetServerAuthCode(callback);
+				}
+				else
+				{
+					GooglePlayGames.OurUtils.Logger.e(
+						"GetServerAuthCode requires a webClientId.");
+					callback(CommonStatusCodes.DeveloperError, "");
+				}
+			}
+			else
+			{
+				GooglePlayGames.OurUtils.Logger.e(
+					"GetServerAuthCode can only be called after authentication.");
+
+				callback(CommonStatusCodes.SignInRequired, "");
+			}
+		}
+
+		/// <summary>
         /// Gets another server auth code.
         /// </summary>
         /// <remarks>This method should be called after authenticating, and exchanging

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -364,6 +364,21 @@ namespace GooglePlayGames.Native
             return mTokenClient.GetAuthCode();
         }
 
+		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+		{
+			PlayGamesHelperObject.RunOnGameThread(() =>
+				mTokenClient.FetchTokens((rc) =>
+				{
+					if (callback != null)
+					{
+						string authCode = mTokenClient.GetAuthCode();
+						PlayGamesHelperObject.RunOnGameThread(() =>
+							callback(CommonStatusCodes.Success, authCode));
+					}
+				}
+			));
+		}
+
         public void GetAnotherServerAuthCode(bool reAuthenticateIfNeeded,
                                              Action<string> callback)
         {


### PR DESCRIPTION
There is a problem currently in the plugin that when the user discards the SignIn Intend displayed at start of the game, this sign in window comes back every time the app is backgrounded and foregrounded again.
This is a suggestion of the implementation to fix that.
Also included is a preference saving when the user discards the account picker at the start so that once discarded, the popup does not show again.