### PR TITLE
#1909 Account Picker displayed after backgrounding/foregrounding app

### DIFF
--- a/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
+++ b/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
@@ -315,9 +315,7 @@ public class TokenFragment extends Fragment
                 );
             } else {
                 Log.d(TAG,"No connected Games API");
-                synchronized (lock) {
-                    pendingTokenRequest = null;
-                }
+                onSignedIn(CommonStatusCodes.ERROR, null);
             }
         }
 
@@ -442,7 +440,6 @@ public class TokenFragment extends Fragment
             if (pendingTokenRequest != null)
             {
                 pendingTokenRequest.cancel();
-                pendingTokenRequest = null;
             }
             SaveDeclinedSignInPreference(true);
         }
@@ -453,8 +450,8 @@ public class TokenFragment extends Fragment
             pendingTokenRequest = null;
         }
         if (request != null) {
-            SaveDeclinedSignInPreference(false);
             if (acct != null) {
+                SaveDeclinedSignInPreference(false);
                 request.setAuthCode(acct.getServerAuthCode());
                 request.setEmail(acct.getEmail());
                 request.setIdToken(acct.getIdToken());

--- a/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
+++ b/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
@@ -438,7 +438,7 @@ public class TokenFragment extends Fragment
 
     private void onSignedIn(int resultCode, GoogleSignInAccount acct) {
 
-        if (resultCode == CommonStatusCodes.CANCELED) {
+        if (pendingTokenRequest != null && resultCode == CommonStatusCodes.CANCELED) {
             pendingTokenRequest.cancel();
             pendingTokenRequest = null;
             SaveDeclinedSignInPreference(true);

--- a/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
+++ b/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
@@ -438,9 +438,12 @@ public class TokenFragment extends Fragment
 
     private void onSignedIn(int resultCode, GoogleSignInAccount acct) {
 
-        if (pendingTokenRequest != null && resultCode == CommonStatusCodes.CANCELED) {
-            pendingTokenRequest.cancel();
-            pendingTokenRequest = null;
+        if (resultCode == CommonStatusCodes.CANCELED) {
+            if (pendingTokenRequest != null)
+            {
+                pendingTokenRequest.cancel();
+                pendingTokenRequest = null;
+            }
             SaveDeclinedSignInPreference(true);
         }
 


### PR DESCRIPTION
There is a problem currently in the plugin that when the user discards the SignIn Intend displayed at start of the game, this sign in window comes back every time the app is backgrounded and foregrounded again.
This is a suggestion of the implementation to fix that.
Also included is a preference saving when the user discards the account picker at the start so that once discarded, the popup does not show again.