### PR TITLE
How to refresh the authCode on request without signOut #1821

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -100,6 +100,15 @@ namespace GooglePlayGames.BasicApi
             return null;
         }
 
+		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+		{
+			LogUsage();
+			if (callback != null)
+			{
+				callback(CommonStatusCodes.ApiNotConnected, "");
+			}
+		}
+
         public void GetAnotherServerAuthCode(bool reAuthenticateIfNeeded,
                                              Action<string> callback)
         {

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -108,7 +108,13 @@ namespace GooglePlayGames.BasicApi
     /// </remarks>
     string GetServerAuthCode();
 
-    /// <summary>
+	/// <summary>
+	/// Retrieves the server auth code for this client.
+	/// </summary>
+	/// <param name="callback">Callback for response.</param>
+	void GetServerAuthCode(Action<CommonStatusCodes, string> callback);
+
+	/// <summary>
     /// Gets another server auth code.
     /// </summary>
     /// <remarks>This method should be called after authenticating, and exchanging

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -108,13 +108,13 @@ namespace GooglePlayGames.BasicApi
     /// </remarks>
     string GetServerAuthCode();
 
-	/// <summary>
-	/// Retrieves the server auth code for this client.
-	/// </summary>
-	/// <param name="callback">Callback for response.</param>
-	void GetServerAuthCode(Action<CommonStatusCodes, string> callback);
+    /// <summary>
+    /// Retrieves the server auth code for this client.
+    /// </summary>
+    /// <param name="callback">Callback for response.</param>
+    void GetServerAuthCode(Action<CommonStatusCodes, string> callback);
 
-	/// <summary>
+    /// <summary>
     /// Gets another server auth code.
     /// </summary>
     /// <remarks>This method should be called after authenticating, and exchanging

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesPlatform.cs
@@ -541,7 +541,39 @@ namespace GooglePlayGames
             return null;
         }
 
-        /// <summary>
+		/// <summary>
+		/// Gets the server auth code.
+		/// </summary>
+		/// <remarks>This code is used by the server application in order to get
+		/// an oauth token.  For how to use this acccess token please see:
+		/// https://developers.google.com/drive/v2/web/auth/web-server
+		/// </remarks>
+		/// <param name="callback">Callback.</param>
+		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+		{
+			if (mClient != null && mClient.IsAuthenticated())
+			{
+				if (GameInfo.WebClientIdInitialized())
+				{
+					mClient.GetServerAuthCode(callback);
+				}
+				else
+				{
+					GooglePlayGames.OurUtils.Logger.e(
+						"GetServerAuthCode requires a webClientId.");
+					callback(CommonStatusCodes.DeveloperError, "");
+				}
+			}
+			else
+			{
+				GooglePlayGames.OurUtils.Logger.e(
+					"GetServerAuthCode can only be called after authentication.");
+
+				callback(CommonStatusCodes.SignInRequired, "");
+			}
+		}
+
+		/// <summary>
         /// Gets another server auth code.
         /// </summary>
         /// <remarks>This method should be called after authenticating, and exchanging

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -364,20 +364,18 @@ namespace GooglePlayGames.Native
             return mTokenClient.GetAuthCode();
         }
 
-		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
-		{
-			PlayGamesHelperObject.RunOnGameThread(() =>
-				mTokenClient.FetchTokens((rc) =>
-				{
-					if (callback != null)
-					{
-						string authCode = mTokenClient.GetAuthCode();
-						PlayGamesHelperObject.RunOnGameThread(() =>
-							callback(CommonStatusCodes.Success, authCode));
-					}
-				}
-			));
-		}
+        public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+        {
+            PlayGamesHelperObject.RunOnGameThread(() =>
+                mTokenClient.FetchTokens((rc) =>
+                {
+                    if (callback != null)
+                    {
+                        callback(CommonStatusCodes.Success, mTokenClient.GetAuthCode());
+                    }
+                }
+            ));
+        }
 
         public void GetAnotherServerAuthCode(bool reAuthenticateIfNeeded,
                                              Action<string> callback)

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs
@@ -364,6 +364,21 @@ namespace GooglePlayGames.Native
             return mTokenClient.GetAuthCode();
         }
 
+		public void GetServerAuthCode(Action<CommonStatusCodes, string> callback)
+		{
+			PlayGamesHelperObject.RunOnGameThread(() =>
+				mTokenClient.FetchTokens((rc) =>
+				{
+					if (callback != null)
+					{
+						string authCode = mTokenClient.GetAuthCode();
+						PlayGamesHelperObject.RunOnGameThread(() =>
+							callback(CommonStatusCodes.Success, authCode));
+					}
+				}
+			));
+		}
+
         public void GetAnotherServerAuthCode(bool reAuthenticateIfNeeded,
                                              Action<string> callback)
         {


### PR DESCRIPTION
A suggestion to how to add the GetAnotherServerAuthCode without adding the extra method in TokenFragment. That is the code i used a while ago when i reported the issue first time (in July). The only thing is that this code will not check for reauthentication, so if this solution is better for you Clay, then your reauthentication code might need to be merged to it as well.