### PR TITLE
Solve namespace error when importing to Unity project with existing Result class

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/Gms/Games/Stats/LoadPlayerStatsResultObject.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/Gms/Games/Stats/LoadPlayerStatsResultObject.cs
@@ -25,7 +25,7 @@ using Com.Google.Android.Gms.Common.Api;
 using UnityEngine;
 namespace Com.Google.Android.Gms.Games.Stats
 {
-    public class Stats_LoadPlayerStatsResultObject : JavaObjWrapper , Stats_LoadPlayerStatsResult, Result
+    public class Stats_LoadPlayerStatsResultObject : JavaObjWrapper , Stats_LoadPlayerStatsResult, Com.Google.Android.Gms.Common.Api.Result
     {
         const string CLASS_NAME = "com/google/android/gms/games/stats/Stats$LoadPlayerStatsResult";
 

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/Gms/Games/Stats/Stats.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/Gms/Games/Stats/Stats.cs
@@ -27,7 +27,7 @@ namespace Com.Google.Android.Gms.Games.Stats
     {
         PendingResult<Stats_LoadPlayerStatsResultObject> loadPlayerStats(GoogleApiClient arg_GoogleApiClient_1, bool arg_bool_2);
     }
-    public interface Stats_LoadPlayerStatsResult : Result
+    public interface Stats_LoadPlayerStatsResult : Com.Google.Android.Gms.Common.Api.Result
     {
         PlayerStats getPlayerStats();
     }


### PR DESCRIPTION
Suggestion to solve the issue: Two Errors When Importing #1581 