### PR TITLE
Fixed issue when the GooglePlayGames folder must be placed in the root of the Assets directory...

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSAndroidSetupUI.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSAndroidSetupUI.cs
@@ -110,6 +110,10 @@ namespace GooglePlayGames.Editor
                 // check the bundle id and set it if needed.
                 CheckBundleId();
 
+                GPGSUtil.CheckAndFixDependencies();
+                GPGSUtil.CheckAndFixVersionedAssestsPaths();
+                AssetDatabase.Refresh();
+
                 Google.VersionHandler.VerboseLoggingEnabled = true;
                 Google.VersionHandler.UpdateVersionedAssets(forceUpdate: true);
                 Google.VersionHandler.Enabled = true;

--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSProjectSettings.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSProjectSettings.cs
@@ -45,8 +45,7 @@ namespace GooglePlayGames.Editor
 
         private GPGSProjectSettings()
         {
-            string ds = Path.DirectorySeparatorChar.ToString();
-            mFile = "ProjectSettings/GooglePlayGameSettings.txt".Replace("/", ds);
+            mFile = GPGSUtil.SlashesToPlatformSeparator("ProjectSettings/GooglePlayGameSettings.txt");
 
             StreamReader rd = null;
 
@@ -54,8 +53,8 @@ namespace GooglePlayGames.Editor
             string[] fileLocations =
                 {
                     mFile,
-                    "Assets/GooglePlayGames/Editor/projsettings.txt".Replace("/", ds),
-                    "Assets/Editor/projsettings.txt".Replace("/", ds)
+                    GPGSUtil.SlashesToPlatformSeparator(Path.Combine(GPGSUtil.RootPath, "Editor/projsettings.txt")),
+                    GPGSUtil.SlashesToPlatformSeparator("Assets/Editor/projsettings.txt")
                 };
 
             foreach (string f in fileLocations)

--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs
@@ -83,7 +83,7 @@ namespace GooglePlayGames.Editor
             {
                 string[] paths =
                     {
-                        "Assets/GooglePlayGames",
+                        GPGSUtil.RootPath,
                         "Assets/Plugins/Android",
                         "Assets/PlayServicesResolver"
                     };

--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
@@ -98,17 +98,92 @@ namespace GooglePlayGames.Editor
         private const string CONSTANTSPLACEHOLDER = "__Constant_Properties__";
 
         /// <summary>
+        /// The game info file path, relative to the plugin root directory.  This is a generated file.
+        /// </summary>
+        private const string GameInfoRelativePath = "GameInfo.cs";
+
+        /// <summary>
+        /// The manifest path, relative to the plugin root directory.
+        /// </summary>
+        /// <remarks>The Games SDK requires additional metadata in the AndroidManifest.xml
+        ///     file. </remarks>
+        private const string ManifestRelativePath =
+           "Plugins/Android/GooglePlayGamesManifest.plugin/AndroidManifest.xml";
+
+        private const string RootFolderName = "GooglePlayGames";
+
+        /// <summary>
+        /// The root path of the Google Play Games plugin
+        /// </summary>
+        public static string RootPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(mRootPath))
+                {
+                    string[] dirs = Directory.GetDirectories("Assets", RootFolderName, SearchOption.AllDirectories);
+                    switch (dirs.Length)
+                    {
+                        case 0:
+                            Alert("Plugin error: GooglePlayGames folder was renamed");
+                            throw new Exception("GooglePlayGames folder was renamed");
+
+                        case 1:
+                            mRootPath = SlashesToPlatformSeparator(dirs[0]);
+                            break;
+
+                        default:
+                            for (int i = 0; i < dirs.Length; i++)
+                            {
+                                if (File.Exists(SlashesToPlatformSeparator(Path.Combine(dirs[i], GameInfoRelativePath))))
+                                {
+                                    mRootPath = SlashesToPlatformSeparator(dirs[i]);
+                                    break;
+                                }
+                            }
+
+                            if (string.IsNullOrEmpty(mRootPath))
+                            {
+                                Alert("Plugin error: GooglePlayGames folder was renamed");
+                                throw new Exception("GooglePlayGames folder was renamed");
+                            }
+
+                            break;
+                    }
+                }
+
+                return mRootPath;
+            }
+        }
+
+        /// <summary>
         /// The game info file path.  This is a generated file.
         /// </summary>
-        private const string GameInfoPath = "Assets/GooglePlayGames/GameInfo.cs";
+        private static string GameInfoPath
+        {
+            get
+            {
+                return SlashesToPlatformSeparator(Path.Combine(RootPath, GameInfoRelativePath));
+            }
+        }
 
         /// <summary>
         /// The manifest path.
         /// </summary>
         /// <remarks>The Games SDK requires additional metadata in the AndroidManifest.xml
         ///     file. </remarks>
-        private const string ManifestPath =
-           "Assets/GooglePlayGames/Plugins/Android/GooglePlayGamesManifest.plugin/AndroidManifest.xml";
+        private static string ManifestPath
+        {
+            get
+            {
+                return SlashesToPlatformSeparator(Path.Combine(RootPath, ManifestRelativePath));
+            }
+        }
+
+        /// <summary>
+        /// The root path of the Google Play Games plugin
+        /// </summary>
+        private static string mRootPath = "";
 
         /// <summary>
         /// The map of replacements for filling in code templates.  The
@@ -166,7 +241,7 @@ namespace GooglePlayGames.Editor
         /// <param name="name">Name of the template in the editor directory.</param>
         public static string ReadEditorTemplate(string name)
         {
-            return ReadFile(SlashesToPlatformSeparator("Assets/GooglePlayGames/Editor/" + name + ".txt"));
+            return ReadFile(Path.Combine(RootPath, string.Format("Editor{0}{1}.txt", Path.DirectorySeparatorChar, name)));
         }
 
         /// <summary>
@@ -419,7 +494,7 @@ namespace GooglePlayGames.Editor
         /// <returns><c>true</c>, if the file exists <c>false</c> otherwise.</returns>
         public static bool AndroidManifestExists()
         {
-            string destFilename = GPGSUtil.SlashesToPlatformSeparator(ManifestPath);
+            string destFilename = ManifestPath;
 
             return File.Exists(destFilename);
         }
@@ -430,7 +505,7 @@ namespace GooglePlayGames.Editor
         public static void GenerateAndroidManifest()
         {
 
-            string destFilename = GPGSUtil.SlashesToPlatformSeparator(ManifestPath);
+            string destFilename = ManifestPath;
 
             // Generate AndroidManifest.xml
             string manifestBody = GPGSUtil.ReadEditorTemplate("template-AndroidManifest");


### PR DESCRIPTION
Now it can be moved into any subfolder in order to reduce a mess in the Assets root and to make a project looks cleaner.