### PR TITLE
Fixed issue with suppressed upgrade dialog when the user uses outdated Play Services

### DIFF
--- a/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
+++ b/source/SupportLib/PlayGamesPluginSupport/src/main/java/com/google/games/bridge/TokenFragment.java
@@ -252,7 +252,8 @@ public class TokenFragment extends Fragment
                             if (exception instanceof ApiException) {
                                 statusCode = ((ApiException) exception).getStatusCode();
                             }
-                            if (statusCode == CommonStatusCodes.SIGN_IN_REQUIRED) {
+                            // INTERNAL_ERROR will be returned if the user has the outdated PlayServices
+                            if (statusCode == CommonStatusCodes.SIGN_IN_REQUIRED || statusCode == CommonStatusCodes.INTERNAL_ERROR) {
                                 if (!request.getSilent()) {
                                     Intent signInIntent = mGoogleSignInClient.getSignInIntent();
                                     startActivityForResult(signInIntent, RC_ACCT);
@@ -520,7 +521,7 @@ public class TokenFragment extends Fragment
     public static View createInvisibleView(Activity parentActivity) {
         View view = new View(parentActivity);
         view.setVisibility(View.INVISIBLE);
-        view.setClickable(false);    
+        view.setClickable(false);
         return view;
     }
 }


### PR DESCRIPTION
If the user has an outdated version of PlayServices, the silentSignIn method will suppress the upgrade dialog, will return "INTERNAL_ERROR" (code 8), and will make the user not being able to log in at all.
This fix makes it possible to run the UI login (if it is not forced to silent from the managed code) which is able to resolve the error and to show the Upgrade Dialog.