### PR TITLE
Fix for missing TokenFragment class

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
@@ -220,6 +220,11 @@ namespace GooglePlayGames.Android
         /// <param name="callback">Callback.</param>
         public void GetAnotherServerAuthCode(bool reAuthenticateIfNeeded, Action<string> callback)
         {
+            PlayGamesHelperObject.RunOnGameThread(() => DoGetAnotherServerAuthCode(reAuthenticateIfNeeded, callback));
+        }
+
+        internal void DoGetAnotherServerAuthCode(bool reAuthenticateIfNeeded, Action<string> callback)
+        {
             object[] objectArray = new object[3];
             jvalue[] jArgs = AndroidJNIHelper.CreateJNIArgArray(objectArray);
 


### PR DESCRIPTION
Resolves "ERROR: Exception launching auth code request: java.lang.ClassNotFoundException: com.google.games.bridge.TokenFragment" - looks like it is executed from wrong thread (fixes use of this method in other threads).

ref #2397 