### PR TITLE
Guard against IndexOutOfRangeException

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/OurUtils/Logger.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/OurUtils/Logger.cs
@@ -85,8 +85,20 @@ namespace GooglePlayGames.OurUtils
 
         private static string ToLogMessage(string prefix, string logType, string msg)
         {
+            string timeString = null;
+            try
+            {
+                timeString = DateTime.Now.ToString("MM/dd/yy H:mm:ss zzz");
+            }
+            catch (Exception)
+            {
+                PlayGamesHelperObject.RunOnGameThread(() =>
+                  Debug.LogWarning("*** [Play Games Plugin DLL] ERROR: Failed to format DateTime.Now"));
+                timeString = string.Empty;
+            }
+
             return string.Format("{0} [Play Games Plugin DLL] {1} {2}: {3}",
-                prefix, DateTime.Now.ToString("MM/dd/yy H:mm:ss zzz"), logType, msg);
+                prefix, timeString, logType, msg);
         }
     }
 }


### PR DESCRIPTION
Got a report of the following exception:
```
IndexOutOfRangeException: Index was outside the bounds of the array.
System.Globalization.GregorianCalendar.GetDatePart (System.Int64 ticks, System.Int32 part) (at <00000000000000000000000000000000>:0)
System.Globalization.GregorianCalendar.GetDayOfMonth (System.DateTime time) (at <00000000000000000000000000000000>:0)
System.DateTimeFormat.FormatCustomized (System.DateTime dateTime, System.String format, System.Globalization.DateTimeFormatInfo dtfi, System.TimeSpan offset) (at <00000000000000000000000000000000>:0)
System.DateTimeFormat.Format (System.DateTime dateTime, System.String format, System.Globalization.DateTimeFormatInfo dtfi, System.TimeSpan offset) (at <00000000000000000000000000000000>:0)
System.DateTimeFormat.Format (System.DateTime dateTime, System.String format, System.Globalization.DateTimeFormatInfo dtfi) (at <00000000000000000000000000000000>:0)
GooglePlayGames.OurUtils.Logger.ToLogMessage (System.String prefix, System.String logType, System.String msg) (at <00000000000000000000000000000000>:0)
GooglePlayGames.OurUtils.Logger+<>c__DisplayClass8_0.<d>b__0 () (at <00000000000000000000000000000000>:0)
GooglePlayGames.OurUtils.PlayGamesHelperObject.Update () (at <00000000000000000000000000000000>:0)
```

So this PR guards against exceptions arising from the DateTime formatting code.