### PR TITLE
Fix DirectoryNotFoundException in GenerateAndroidManifest() (#1966)

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
@@ -252,6 +252,8 @@ namespace GooglePlayGames.Editor
         public static void WriteFile(string file, string body)
         {
             file = SlashesToPlatformSeparator(file);
+            DirectoryInfo dir = Directory.GetParent(file);
+            dir.Create();
             using (var wr = new StreamWriter(file, false))
             {
                 wr.Write(body);


### PR DESCRIPTION
Full stack trace:
```
System.IO.DirectoryNotFoundException: Could not find a part of the path "Assets\GooglePlayGames\Plugins\Android\GooglePlayGamesManifest.plugin\AndroidManifest.xml".
  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options) [0x001be] in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.IO/FileStream.cs:292 
  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)
  at System.IO.StreamWriter..ctor (System.String path, Boolean append, System.Text.Encoding encoding, Int32 bufferSize) [0x00039] in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.IO/StreamWriter.cs:124 
  at System.IO.StreamWriter..ctor (System.String path, Boolean append) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.IO.StreamWriter:.ctor (string,bool)
  at GooglePlayGames.Editor.GPGSUtil.WriteFile (System.String file, System.String body) [0x0000b] in Assets\GooglePlayGames\Editor\GPGSUtil.cs:255 
  at GooglePlayGames.Editor.GPGSUtil.GenerateAndroidManifest () [0x000db] in Assets\GooglePlayGames\Editor\GPGSUtil.cs:543 
  at GooglePlayGames.Editor.GPGSUpgrader..cctor () [0x0018a] in Assets\GooglePlayGames\Editor\GPGSUpgrader.cs:111 
UnityEditor.EditorAssemblies:ProcessInitializeOnLoadAttributes()
```