### PR TITLE
Correct semantics for HasRematchId predicate

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeTurnBasedMatch.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/NativeTurnBasedMatch.cs
@@ -114,7 +114,7 @@ namespace GooglePlayGames.Native.PInvoke
         internal bool HasRematchId()
         {
             string rematchId = RematchId();
-            return string.IsNullOrEmpty(rematchId) ||  !rematchId.Equals("(null)");
+            return !string.IsNullOrEmpty(rematchId) && !rematchId.Equals("(null)");
         }
 
         internal string RematchId()


### PR DESCRIPTION
HasRematchId needs to return true if the RematchId is different from null, "" or "(null)". In the previous implementation, however, it returned true when RematchId was null or "", so the logic was reversed for most cases (would have worked only for string "(null)").