### PR TITLE
Exposure of GetMatch for given matchId 

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/Multiplayer/ITurnBasedMultiplayerClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/Multiplayer/ITurnBasedMultiplayerClient.cs
@@ -95,6 +95,13 @@ namespace GooglePlayGames.BasicApi.Multiplayer
         void GetAllMatches(Action<TurnBasedMatch[]> callback);
 
         /// <summary>
+        /// Gets match for given match id.
+        /// </summary>
+        /// <param name="matchId">Match id</param>
+        /// <param name="callback">Callback.</param>
+        void GetMatch(string matchId, Action<bool, TurnBasedMatch> callback);
+        
+        /// <summary>
         /// Starts a game by showing the match inbox.</summary>
         /// <remarks> The player's match inbox will be
         /// shown, allowing the player to pick an ongoing match or accept an outstanding

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeTurnBasedMultiplayerClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeTurnBasedMultiplayerClient.cs
@@ -157,6 +157,25 @@ namespace GooglePlayGames.Native
                     callback(matches);
                 });
         }
+        
+        public void GetMatch(string matchId, Action<bool, TurnBasedMatch> callback)
+        {
+            mTurnBasedManager.GetMatch(matchId, response =>
+            {
+                using (var foundMatch = response.Match())
+                {
+                    if (foundMatch == null)
+                    {
+                        Logger.e(string.Format("Could not find match {0}", matchId));
+                        callback(false, null);
+                    }
+                    else
+                    {
+                        callback(true, foundMatch.AsTurnBasedMatch(mNativeClient.GetUserId()));
+                    }
+                }
+            });
+        }
 
         private Action<TurnBasedManager.TurnBasedMatchResponse> BridgeMatchToUserCallback(
             Action<UIStatus, TurnBasedMatch> userCallback)


### PR DESCRIPTION
The regular Android play games API exposes a loadMatch API to load a specific match for a give ID. The Unity plugin so far just had GetAllMatches to load a list of all the user's matches. After saving a turn for a user, though, it is required to reload the updated match from the server, and it is inconvenient to do this via GetAllMatches rather than just load that very match for the given id.

This pull request implements a GetMatch fct. next to GetAllMatches (+ interface). 