### PR TITLE
TBM: Expose creation time of invitation

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/Multiplayer/Invitation.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/Multiplayer/Invitation.cs
@@ -15,14 +15,21 @@
 // </copyright>
 #if UNITY_ANDROID
 
+using System;
+
 namespace GooglePlayGames.BasicApi.Multiplayer
 {
+
     /// <summary>
     /// Represents an invitation to a multiplayer game. The invitation may be for
     /// a turn-based or real-time game.
     /// </summary>
     public class Invitation
     {
+        static readonly DateTime UnixEpoch =
+                new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+
         public enum InvType
         {
             RealTime,
@@ -34,13 +41,15 @@ namespace GooglePlayGames.BasicApi.Multiplayer
         private string mInvitationId;
         private Participant mInviter;
         private int mVariant;
+        private long mCreationTime;
 
-        internal Invitation(InvType invType, string invId, Participant inviter, int variant)
+        internal Invitation(InvType invType, string invId, Participant inviter, int variant, long creationTime)
         {
             mInvitationType = invType;
             mInvitationId = invId;
             mInviter = inviter;
             mVariant = variant;
+            mCreationTime = creationTime;
         }
 
         /// <summary>
@@ -92,6 +101,19 @@ namespace GooglePlayGames.BasicApi.Multiplayer
                 return mVariant;
             }
         }
+
+        /// <summary>
+        /// Gets the creation time of the invitation
+        /// </summary>
+        /// <value>The creation timestamp (UTC)</value>
+        public DateTime CreationTime
+        {
+            get
+            {
+                return UnixEpoch.AddMilliseconds(mCreationTime);
+            }
+        }
+
 
         public override string ToString()
         {

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/MultiplayerInvitation.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/MultiplayerInvitation.cs
@@ -52,6 +52,11 @@ namespace GooglePlayGames.Native.PInvoke
             return C.MultiplayerInvitation_Variant(SelfPtr());
         }
 
+        internal ulong CreationTime()
+        {
+            return C.MultiplayerInvitation_CreationTime(SelfPtr());
+        }
+
         internal Types.MultiplayerInvitationType Type()
         {
             return C.MultiplayerInvitation_Type(SelfPtr());
@@ -98,6 +103,8 @@ namespace GooglePlayGames.Native.PInvoke
             var type = ToInvType(Type());
             var invitationId = Id();
             int variant = (int)Variant();
+            long creationTime = (long)CreationTime();
+            
             Participant inviter;
 
             using (var nativeInviter = Inviter())
@@ -105,7 +112,7 @@ namespace GooglePlayGames.Native.PInvoke
                 inviter = nativeInviter == null ? null : nativeInviter.AsParticipant();
             }
 
-            return new Invitation(type, invitationId, inviter, variant);
+            return new Invitation(type, invitationId, inviter, variant, creationTime);
         }
 
         internal static MultiplayerInvitation FromPointer(IntPtr selfPointer)


### PR DESCRIPTION
To be able to create a proper Unity UI for invitations (if you don't want to use stock intents), the creation time stamp of the invitation is required. This PR exposes it to the Unity API.