### PR TITLE
Fix build issue in Unity 2019.1

### DIFF
--- a/source/build.gradle
+++ b/source/build.gradle
@@ -357,8 +357,10 @@ task inject_versionIntoMetaFiles() {
     for (fileobj in fileTree("${pluginProj}")) {
       if (fileobj.path.endsWith('.meta')) {
         // Skip the manifest files for any previous versions
+        // Skip any files in 'PackageCache' subdirectory
         if (fileobj.path.contains("Editor/${currentPluginBasename}") &&
-            !fileobj.path.contains(currentManifestFile)) {
+            !fileobj.path.contains(currentManifestFile) ||
+                fileobj.path.contains("PackageCache")) {
           continue
         }
         def lines = fileobj.text.split('\n')


### PR DESCRIPTION
Fix issue where build using Unity version 2019.1 fails on error during inject_versionIntoMetaFiles task:
FileNotFoundException: .../play-games-plugin-for-unity/source/build/PluginProject/Library/PackageCache/com.unity.ads@2.0.8/CHANGELOG.md.meta