### PR TITLE
Fix for AndroidJNI deprecation warnings

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/Developers/JavaObjWrapper.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/Developers/JavaObjWrapper.cs
@@ -349,7 +349,11 @@ namespace Google.Developers
                 }
                 else if (t == typeof(byte))
                 {
+#if UNITY_2019_1_OR_NEWER
+                    return (T)(object)AndroidJNI.CallSByteMethod(raw, method, jArgs);
+#else
                     return (T)(object)AndroidJNI.CallByteMethod(raw, method, jArgs);
+#endif
                 }
                 else if (t == typeof(char))
                 {
@@ -414,8 +418,13 @@ namespace Google.Developers
                 }
                 else if (t == typeof(byte))
                 {
+#if UNITY_2019_1_OR_NEWER
+                    return (T)(object)AndroidJNI.CallStaticSByteMethod(
+                        rawClass, method, jArgs);
+#else
                     return (T)(object)AndroidJNI.CallStaticByteMethod(
                         rawClass, method, jArgs);
+#endif
                 }
                 else if (t == typeof(char))
                 {


### PR DESCRIPTION
In Unity 2019.1 and above, the methods `AndroidJNI.CallByteMethod` and `AndroidJNI.CallStaticByteMethod` were deprecated and replaced by methods  `AndroidJNI.CallSByteMethod` and `AndroidJNI.CallStaticSByteMethod`.

**Refs**
https://docs.unity3d.com/2019.1/Documentation/ScriptReference/AndroidJNI.FromByteArray.html

**Solved issues**
#2559 
#2663 
warning mentioned in https://github.com/playgameservices/play-games-plugin-for-unity/issues/2647#issuecomment-515335179
part of #2664

However this outputs sbyte instead of byte (although it will be converted to byte) so I leave it as draft pull request for now. Should InvokeCall and StaticInvokeCall support sbyte instead of byte (so it matches java byte) or support them both?