### PR TITLE
Return local player id instead of "me".

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
@@ -928,11 +928,10 @@ namespace GooglePlayGames.Android
                 {
                     System.DateTime date = AndroidJavaConverter.ToDateTime(0);
                     ulong rank = (ulong) variant.Call<long>("getPlayerRank");
-                    string scoreHolderId = "me";
                     ulong score = (ulong) variant.Call<long>("getRawPlayerScore");
                     string metadata = variant.Call<string>("getPlayerScoreTag");
                     leaderboardScoreData.PlayerScore = new PlayGamesScore(date, leaderboardId,
-                        rank, scoreHolderId, score, metadata);
+                        rank, mUser.id, score, metadata);
                 }
 
                 leaderboardScoreData.ApproximateCount = (ulong) variant.Call<long>("getNumScores");


### PR DESCRIPTION
- Issue reported [here ](https://github.com/playgameservices/play-games-plugin-for-unity/issues/2687#issuecomment-524519045)

- In the old plugin code, local player id is passed in [NativeClient](https://github.com/playgameservices/play-games-plugin-for-unity/blob/master/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/NativeClient.cs#L819)
and then used [here](https://github.com/playgameservices/play-games-plugin-for-unity/blob/master/source/PluginDev/Assets/GooglePlayGames/Platforms/Native/PInvoke/LeaderboardManager.cs#L194)