### PR TITLE
Don't use using statement in commitUpdate method 

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidSavedGameClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidSavedGameClient.cs
@@ -273,6 +273,7 @@ namespace GooglePlayGames.Android
             {
                 AndroidTaskUtils.AddOnSuccessListener<AndroidJavaObject>(
                     task,
+                    /* disposeResult= */ false,
                     snapshotMetadata =>
                     {
                         Debug.Log("commitAndClose.succeed");

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTaskUtils.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTaskUtils.cs
@@ -13,7 +13,13 @@ namespace GooglePlayGames.Android
 
         public static void AddOnSuccessListener<T>(AndroidJavaObject task, Action<T> callback)
         {
-            using (task.Call<AndroidJavaObject>("addOnSuccessListener", new TaskOnSuccessProxy<T>(callback))) ;
+            using (task.Call<AndroidJavaObject>("addOnSuccessListener",
+                new TaskOnSuccessProxy<T>(callback, /* disposeResult= */ true))) ;
+        }
+
+        public static void AddOnSuccessListener<T>(AndroidJavaObject task, bool disposeResult, Action<T> callback)
+        {
+            using (task.Call<AndroidJavaObject>("addOnSuccessListener", new TaskOnSuccessProxy<T>(callback, disposeResult))) ;
         }
 
         public static void AddOnFailureListener(AndroidJavaObject task, Action<AndroidJavaObject> callback)
@@ -56,16 +62,18 @@ namespace GooglePlayGames.Android
         {
             private Action<T> mCallback;
             private Action<AndroidJavaObject> mCallback2;
+            private bool mDisposeResult;
 
-            public TaskOnSuccessProxy(Action<T> callback)
+            public TaskOnSuccessProxy(Action<T> callback, bool disposeResult)
                 : base("com/google/android/gms/tasks/OnSuccessListener")
             {
                 mCallback = callback;
+                mDisposeResult = disposeResult;
             }
 
             public void onSuccess(T result)
             {
-                if (result is IDisposable)
+                if (result is IDisposable && mDisposeResult)
                 {
                     using ((IDisposable) result)
                     {


### PR DESCRIPTION
to prevent crashes that happen in AndroidSnapshotMetadata.

- I checked 3 other places where an AndroidSnapshotMetadata instance is created. None of them looked to need an update. 