### PR TITLE
Fix SmokeTest app build for older Unity versions

### DIFF
--- a/samples/SmokeTest/Source/Assets/SmokeTest/NearbyGUI.cs
+++ b/samples/SmokeTest/Source/Assets/SmokeTest/NearbyGUI.cs
@@ -21,7 +21,7 @@ namespace SmokeTest
     using GooglePlayGames;
     using GooglePlayGames.BasicApi.Nearby;
     using UnityEngine;
-#if UNITY_ANDROID
+#if UNITY_ANDROID && UNITY_2019
     using UnityEngine.Android;
 #endif
 
@@ -72,7 +72,7 @@ namespace SmokeTest
             mMessageLog = new List<string>();
             mKnownEndpoints = new HashSet<string>();
             
-#if UNITY_ANDROID
+#if UNITY_ANDROID && UNITY_2019
             Permission.RequestUserPermission(Permission.FineLocation);
             Permission.RequestUserPermission(Permission.CoarseLocation);
 #endif


### PR DESCRIPTION
Tested for versions 5.6, 2017.3, 2018.2, 2019.1, 2019.2 [cl/277367077]