### PR TITLE
Fixed compile errors in Unity 2017.1 and 2017.2

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSProjectSettings.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSProjectSettings.cs
@@ -20,7 +20,7 @@ namespace GooglePlayGames.Editor
 {
     using System.Collections.Generic;
     using System.IO;
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_3_OR_NEWER
     using UnityEngine.Networking;
 #else
     using UnityEngine;
@@ -102,7 +102,7 @@ namespace GooglePlayGames.Editor
             }
             else if (mDict.ContainsKey(key))
             {
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_3_OR_NEWER
                 return UnityWebRequest.UnEscapeURL(mDict[key]);
 #else
                 return WWW.UnEscapeURL(mDict[key]);
@@ -118,7 +118,7 @@ namespace GooglePlayGames.Editor
         {
             if (mDict.ContainsKey(key))
             {
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_3_OR_NEWER
                 return UnityWebRequest.UnEscapeURL(mDict[key]);
 #else
                 return WWW.UnEscapeURL(mDict[key]);
@@ -147,7 +147,7 @@ namespace GooglePlayGames.Editor
 
         public void Set(string key, string val)
         {
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_3_OR_NEWER
             string escaped = UnityWebRequest.EscapeURL(val);
 #else
             string escaped = WWW.EscapeURL(val);

--- a/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesUserProfile.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/ISocialPlatform/PlayGamesUserProfile.cs
@@ -22,7 +22,7 @@ namespace GooglePlayGames
     using System.Collections;
     using GooglePlayGames.OurUtils;
     using UnityEngine;
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
     using UnityEngine.Networking;
 #endif
     using UnityEngine.SocialPlatforms;
@@ -120,7 +120,7 @@ namespace GooglePlayGames
             // avatar configured.
             if (!string.IsNullOrEmpty(AvatarURL))
             {
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
                 UnityWebRequest www = UnityWebRequestTexture.GetTexture(AvatarURL);
                 www.SendWebRequest();
 #else
@@ -133,7 +133,7 @@ namespace GooglePlayGames
 
                 if (www.error == null)
                 {
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
                     this.mImage = DownloadHandlerTexture.GetContent(www);
 #else
                     this.mImage = www.texture;


### PR DESCRIPTION
### Changes
Changed `#if UNITY_2017_1_OR_NEWER` to `#if UNITY_2017_3_OR_NEWER` in `GPGSProjectSettings.cs` because the methods `UnityWebRequest.EscapeURL` and `UnityWebRequest.UnEscapeURL` were introduced in [Unity 2017.3](https://docs.unity3d.com/2017.3/Documentation/ScriptReference/Networking.UnityWebRequest.html).

Changed `#if UNITY_2017_1_OR_NEWER` to `#if UNITY_2017_2_OR_NEWER` in `PlayGamesUserProfile.cs` because the method `UnityWebRequest.SendWebRequest`was introduced in [Unity 2017.2](https://docs.unity3d.com/2017.2/Documentation/ScriptReference/Networking.UnityWebRequest.html).

### Documentation
You can see the changes to the API in the legacy docs:
[UnityWebRequest 2017.1](https://docs.unity3d.com/2017.1/Documentation/ScriptReference/Networking.UnityWebRequest.html)
[UnityWebRequest 2017.2](https://docs.unity3d.com/2017.2/Documentation/ScriptReference/Networking.UnityWebRequest.html)
[UnityWebRequest 2017.3](https://docs.unity3d.com/2017.3/Documentation/ScriptReference/Networking.UnityWebRequest.html)