### PR TITLE
Fix ToDateTime() always returning 01/01/1970

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidJavaConverter.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidJavaConverter.cs
@@ -30,8 +30,7 @@ namespace GooglePlayGames.Android
         internal static System.DateTime ToDateTime(long milliseconds)
         {
             System.DateTime result = new System.DateTime(1970, 1, 1, 0, 0, 0, 0);
-            result.AddMilliseconds(milliseconds);
-            return result;
+            return result.AddMilliseconds(milliseconds);
         }
 
         // Convert to LeaderboardVariant.java#TimeSpan


### PR DESCRIPTION
result.AddMilliseconds() doesn't change the value of result - it returns a new DateTime which was ignored and therefore ToDateTime() was always returning 01/01/1970