### PR TITLE
Disabling GPGSUpgrader automatic process whe pressing Play in Editor mode

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs
@@ -33,6 +33,8 @@ namespace GooglePlayGames.Editor
         /// </summary>
         static GPGSUpgrader()
         {
+			if (EditorApplication.isPlayingOrWillChangePlaymode)
+				return;
             Debug.Log("GPGSUpgrader start");
             string initialVer = GPGSProjectSettings.Instance.Get(GPGSUtil.LASTUPGRADEKEY, "00000");
             if (!initialVer.Equals(PluginVersion.VersionKey))

--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs
@@ -33,8 +33,8 @@ namespace GooglePlayGames.Editor
         /// </summary>
         static GPGSUpgrader()
         {
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-				return;
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
             Debug.Log("GPGSUpgrader start");
             string initialVer = GPGSProjectSettings.Instance.Get(GPGSUtil.LASTUPGRADEKEY, "00000");
             if (!initialVer.Equals(PluginVersion.VersionKey))


### PR DESCRIPTION
There is multiple reasons:
- This method is causing an error each time we press play (Unity 2017.4).
- To avoid unesssary overhead when pressing Play.

The method will still be called every time the project recompile or when we open the project, which is already enough for its purpose.
We used a patched version of this script for quite some time without issues.

The recuring error fixed by this PR:


> NullReferenceException: Object reference not set to an instance of an object
> UnityEditor.InspectorWindow.OnSelectionChange () (at C:/buildslave/unity/build/Editor/Mono/Inspector/InspectorWindow.cs:147)
> System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MonoMethod.cs:222)
> Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
> System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MonoMethod.cs:232)
> System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MethodBase.cs:115)
> UnityEditor.HostView.Invoke (System.String methodName, System.Object obj) (at C:/buildslave/unity/build/Editor/Mono/HostView.cs:295)
> UnityEditor.HostView.Invoke (System.String methodName) (at C:/buildslave/unity/build/Editor/Mono/HostView.cs:288)
> UnityEditor.HostView.OnSelectionChange () (at C:/buildslave/unity/build/Editor/Mono/HostView.cs:168)
> UnityEditor.AssetDatabase:Refresh()
> GooglePlayGames.Editor.GPGSUpgrader:.cctor() (at Assets/GooglePlayGames/Editor/GPGSUpgrader.cs:102)
> UnityEditor.EditorAssemblies:ProcessInitializeOnLoadAttributes()
