### PR TITLE
add Dictionary for generated constants

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
@@ -18,6 +18,7 @@
 namespace GooglePlayGames.Editor
 {
     using System;
+    using System.Text;
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
@@ -96,6 +97,9 @@ namespace GooglePlayGames.Editor
 
         /// <summary>Constant for token replacement</summary>
         private const string CONSTANTSPLACEHOLDER = "__Constant_Properties__";
+
+        /// <summary>Constant for token replacement</summary>
+        private const string DICTIONARYPLACEHOLDER = "__DictionaryIds__";
 
         /// <summary>
         /// The game info file path, relative to the plugin root directory.  This is a generated file.
@@ -566,6 +570,9 @@ namespace GooglePlayGames.Editor
         public static void WriteResourceIds(string classDirectory, string className, Hashtable resourceKeys)
         {
             string constantsValues = string.Empty;
+            StringBuilder disctionaryValuesStringBuilder = new StringBuilder()
+                .AppendLine("        public static readonly Dictionary<string, string> Dictionary = new Dictionary<string, string>{");
+
             string[] parts = className.Split('.');
             string dirName = classDirectory;
             if (string.IsNullOrEmpty(dirName))
@@ -591,7 +598,9 @@ namespace GooglePlayGames.Editor
                 string key = MakeIdentifier((string) ent.Key);
                 constantsValues += "        public const string " +
                                    key + " = \"" + ent.Value + "\"; // <GPGSID>\n";
+                disctionaryValuesStringBuilder.AppendLine($"            {{\"{key}\", \"{ent.Value}\"}},");
             }
+            disctionaryValuesStringBuilder.AppendLine("        };");
 
             string fileBody = GPGSUtil.ReadEditorTemplate("template-Constants");
             if (nameSpace != string.Empty)
@@ -607,6 +616,7 @@ namespace GooglePlayGames.Editor
 
             fileBody = fileBody.Replace(CLASSNAMEPLACEHOLDER, parts[parts.Length - 1]);
             fileBody = fileBody.Replace(CONSTANTSPLACEHOLDER, constantsValues);
+            fileBody = fileBody.Replace(DICTIONARYPLACEHOLDER, disctionaryValuesStringBuilder.ToString());
             if (nameSpace != string.Empty)
             {
                 fileBody = fileBody.Replace(

--- a/source/PluginDev/Assets/GooglePlayGames/Editor/template-Constants.txt
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/template-Constants.txt
@@ -21,9 +21,27 @@
 /// Resources.
 ///
 
+using System.Collections.Generic;
+
 __NameSpaceStart__
 public static class __Class__
 {
 __Constant_Properties__
+
+__DictionaryIds__
+
+        /// <summary>
+        /// Return the leaderboard id by the leaderboard name or null if the leaderboard name does not exist.
+        /// </summary>
+        /// <returns>Leaderboard id or null.</returns>
+        /// <param name="leaderboardName">Leaderboard id or null in case the leaderboard name has not been found.</param>
+        public static string GetLeaderboardId(string leaderboardName)
+        {
+            if (Dictionary.ContainsKey(leaderboardName)) {
+                return Dictionary[leaderboardName];
+            }
+
+            return null;
+        }
 }
 __NameSpaceEnd__


### PR DESCRIPTION
In order to programmatically access the `LeaderboardId` you would need to use reflection which has a big impact on game performance.

I have extended the code generator to include also the Dictionary and a simple method which will return the `Id` if found and `null` in case it has not been found.

Example usage:
```
string prefix = "leaderboard";
string leaderboardName = $"{prefix}_{levelId}"

Constants.GetLeaderboardId(leaderboardName);
```

I believe this will be very helpful because the other option would be to have something like this in every single game:
```
private Dictionary<string, string> Leaderboards = new Dictionary<string, string>{
  {"level01", Constants.leaderboard_level01}
}
```

which is also doable but if you have two environments (Staging & Production) you will end up with two maps and if your game contains more than 100 levels it will be very error-prone to create the dictionary by hand.


There are pros and cons for this approach

The biggest advantage is that you don't need to create the map by hand anymore.
The biggest disadvantage is that this approach will not ensure the leaderboard needs to exist because this can not be checked during compile time.

But I would say this is on every single developer to choose the approach.