### PR TITLE
Search SDK path correctly on Unity 2020

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
@@ -445,7 +445,7 @@ namespace GooglePlayGames.Editor
         public static string GetAndroidSdkPath()
         {
             string sdkPath = EditorPrefs.GetString("AndroidSdkRoot");
-#if UNITY_2019
+#if UNITY_2019 || UNITY_2020
             // Unity 2019.x added installation of the Android SDK in the AndroidPlayer directory
             // so fallback to searching for it there.
             if (string.IsNullOrEmpty(sdkPath) || EditorPrefs.GetBool("SdkUseEmbedded"))


### PR DESCRIPTION
Previous version of code supported correct SDK path search only for Unity 2019 and broke on 2020. Realated to issue #2947