### PR TITLE
Search SDK path correctly on Unity 2021.

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUtil.cs
@@ -445,7 +445,7 @@ namespace GooglePlayGames.Editor
         public static string GetAndroidSdkPath()
         {
             string sdkPath = EditorPrefs.GetString("AndroidSdkRoot");
-#if UNITY_2019 || UNITY_2020
+#if UNITY_2019_1_OR_NEWER
             // Unity 2019.x added installation of the Android SDK in the AndroidPlayer directory
             // so fallback to searching for it there.
             if (string.IsNullOrEmpty(sdkPath) || EditorPrefs.GetBool("SdkUseEmbedded"))


### PR DESCRIPTION
According to [official documentation](https://docs.unity3d.com/Manual/PlatformDependentCompilation.html) Unity has **UNITY_X_Y_OR_NEWER** macros. I think in this case it is more appropriate.