### PR TITLE
Save newly generated serverAuthCode when calling GetAnotherServerAuthCode

### DIFF
--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidTokenClient.cs
@@ -257,7 +257,7 @@ namespace GooglePlayGames.Android
                     /* accountName= */ ""))
                 {
                     pendingResult.Call("setResultCallback", new ResultCallbackProxy(
-                        tokenResult => { callback(tokenResult.Call<string>("getAuthCode")); }));
+                        tokenResult => { callback(authCode = tokenResult.Call<string>("getAuthCode")); }));
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
When GetAnotherServerAuthCode is called, newly generated authCode is not saved, or in other words, GetServerAuthCode() still returns the old one, which doesn't make much sense, since server can verify authCode only once. After first verification of auth code, Google Play Games Service will return "invalid_grant" if you try to verify it again, so I think it doesn't make sense to keep the old one when you generate a new auth code.