### PR TITLE
Added forceReload parameter on LoadScores method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+This form is for reporting Unity Plugin issues only. To report an issue with the Play Games Service (non-SDK related), check [Google Play Games Services Support](https://developers.google.com/games/services/support).
+*Once you've read this section and determined that your issue is appropriate for this repository, please delete this section.*
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. ___
+2. ___
+3. ___
+4. ___
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Observed behavior**
+A clear and concise description of what you observed.
+
+**Bug Report**
+[Capture](https://developer.android.com/studio/debug/bug-report) a bug report and share the Google Drive link. If the bug report contains sensitive information, then make it private and only give access to requests from `...@google.com` accounts.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Versions**
+- Unity version: ___
+- Google Play Games Plugin for Unity version: ___
+
+**Additional context**
+Add any other context about the problem here.

--- a/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/BaseMockPlayGamesClient.cs
+++ b/source/PluginDev.UnitTests/GooglePlayGames/ISocialPlatform/BaseMockPlayGamesClient.cs
@@ -155,7 +155,8 @@ class BaseMockPlayGamesClient : IPlayGamesClient {
     public virtual void LoadScores(string leaderboardId, LeaderboardStart start,
             int rowCount, LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback) {
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false) {
         throw new NotSupportedException("unsupported");
     }
 

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/DummyClient.cs
@@ -339,13 +339,15 @@ namespace GooglePlayGames.BasicApi
         /// <param name="collection">Collection to display.</param>
         /// <param name="timeSpan">Time span.</param>
         /// <param name="callback">Callback to invoke when complete.</param>
+        /// <param name="forceReload">if true, this will delete local data and fetch it again from the server.</param>
         public void LoadScores(
             string leaderboardId,
             LeaderboardStart start,
             int rowCount,
             LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback)
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false)
         {
             LogUsage();
             if (callback != null)

--- a/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/BasicApi/IPlayGamesClient.cs
@@ -319,10 +319,12 @@ namespace GooglePlayGames.BasicApi
         /// <param name="timeSpan">leaderboard timespan</param>
         /// <param name="callback">callback with the scores, and a page token.
         ///   The token can be used to load next/prev pages.</param>
+        /// <param name="forceReload">if true, this will delete local data and fetch it again from the server.</param>
         void LoadScores(string leaderboardId, LeaderboardStart start,
             int rowCount, LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback);
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false);
 
         /// <summary>
         /// Loads the more scores for the leaderboard.

--- a/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
+++ b/source/PluginDev/Assets/GooglePlayGames/Platforms/Android/AndroidClient.cs
@@ -965,7 +965,8 @@ namespace GooglePlayGames.Android
         public void LoadScores(string leaderboardId, LeaderboardStart start,
             int rowCount, LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback)
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false)
         {
             using (var client = getLeaderboardsClient())
             {
@@ -976,7 +977,8 @@ namespace GooglePlayGames.Android
                     leaderboardId,
                     AndroidJavaConverter.ToLeaderboardVariantTimeSpan(timeSpan),
                     AndroidJavaConverter.ToLeaderboardVariantCollection(collection),
-                    rowCount))
+                    rowCount,
+                    forceReload))
                 {
                     AndroidTaskUtils.AddOnSuccessListener<AndroidJavaObject>(
                         task,


### PR DESCRIPTION
I have had some problems with the cache update when calling LoadScores method, so I decided to add the forceReload parameter. This parameter is defined on:
* https://developers.google.com/android/reference/com/google/android/gms/games/LeaderboardsClient#loadPlayerCenteredScores(java.lang.String,%20int,%20int,%20int,%20boolean)
* https://developers.google.com/android/reference/com/google/android/gms/games/LeaderboardsClient#loadTopScores(java.lang.String,%20int,%20int,%20int,%20boolean)

I have added the `false` default value in order to keep compatibility with older versions of the package.