### PR TITLE
Fixed issue when the GooglePlayGames is placed of the Assets directory.

### DIFF
--- a/Assets/Public/GooglePlayGames/com.google.play.games/Editor/GPGSUtil.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Editor/GPGSUtil.cs
@@ -22,6 +22,7 @@ namespace GooglePlayGames.Editor
     using System.Collections.Generic;
     using System.IO;
     using System.Xml;
+    using System.Linq;
     using UnityEditor;
     using UnityEngine;
 
@@ -108,7 +109,7 @@ namespace GooglePlayGames.Editor
         /// <remarks>The Games SDK requires additional metadata in the AndroidManifest.xml
         ///     file. </remarks>
         private const string ManifestRelativePath =
-            "../../Plugins/Android/GooglePlayGamesManifest.androidlib/AndroidManifest.xml";
+            "Plugins/Android/GooglePlayGamesManifest.androidlib/AndroidManifest.xml";
 
         private const string RootFolderName = "com.google.play.games";
 
@@ -187,7 +188,17 @@ namespace GooglePlayGames.Editor
         ///     file. </remarks>
         private static string ManifestPath
         {
-            get { return SlashesToPlatformSeparator(Path.Combine(RootPath, ManifestRelativePath)); }
+            get
+            {
+                bool isInAssetsDir = RootPath.Split(Path.DirectorySeparatorChar)
+                    .Contains("Assets");
+
+                string manifestPath = isInAssetsDir
+                    ? Path.Combine(RootPath, "../../", ManifestRelativePath)
+                    : Path.Combine(Application.dataPath, ManifestRelativePath);
+
+                return SlashesToPlatformSeparator(manifestPath);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When GooglePlayGames Package location is out of Assets for using UPM(UnityPackageManager) way,
GooglePlayGamesManifest.androidlib is generated at wrong path. 

In my case, Plugins/GooglePlayGamesManifest.androidlib was generated at Project root path not in Assets, so could not included it during build.

For using UPM, Additional files must be generated in Assets.