### PR TITLE
Bug fix PlayGamesAchievement.cs

### DIFF
--- a/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/ISocialPlatform/PlayGamesAchievement.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/ISocialPlatform/PlayGamesAchievement.cs
@@ -89,7 +89,7 @@ namespace GooglePlayGames
             }
 
             this.mCompleted = ach.IsUnlocked;
-            this.mHidden = !ach.IsRevealed;
+            this.mHidden = !ach.IsRevealed && !ach.IsUnlocked;
             this.mLastModifiedTime = ach.LastModifiedTime;
             this.mTitle = ach.Name;
             this.mDescription = ach.Description;
@@ -135,8 +135,10 @@ namespace GooglePlayGames
                 {
 #if UNITY_2017_1_OR_NEWER
                     mImageFetcher = UnityWebRequestTexture.GetTexture(url);
+                    mImageFetcher.SendWebRequest();
 #else
                     mImageFetcher = new WWW(url);
+                    mImageFetcher.Send();
 #endif
                     mImage = null;
                 }


### PR DESCRIPTION
Fixes:
1- Method `LoadImage` always returning `null`;
2- `hidden` property returning false when achievement had already been unlocked, this issue also made `LoadImage` return `null` values.