### PR TITLE
#2674 PlayGamesPlatform.Instance.LoadScores returns old scores

### DIFF
--- a/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/BasicApi/DummyClient.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/BasicApi/DummyClient.cs
@@ -218,7 +218,8 @@ namespace GooglePlayGames.BasicApi
             int rowCount,
             LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback)
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false)
         {
             LogUsage();
             if (callback != null)

--- a/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/BasicApi/IPlayGamesClient.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/BasicApi/IPlayGamesClient.cs
@@ -298,9 +298,14 @@ namespace GooglePlayGames.BasicApi
       /// <param name="timeSpan">leaderboard timespan</param>
       /// <param name="callback">callback with the scores, and a page token.
       ///   The token can be used to load next/prev pages.</param>
+      /// <param name="forceReload">
+      /// If true, this call will clear any locally cached data and attempt to
+      /// fetch the latest data from the server. This would commonly be used for something like a
+      /// user-initiated refresh. Normally, this should be set to {@code false} to gain advantages
+      /// of data caching.</param>
       void LoadScores(string leaderboardId, LeaderboardStart start, int rowCount,
                       LeaderboardCollection collection, LeaderboardTimeSpan timeSpan,
-                      Action<LeaderboardScoreData> callback);
+                      Action<LeaderboardScoreData> callback, bool forceReload = false);
 
       /// <summary>
       /// Loads the more scores for the leaderboard.

--- a/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/ISocialPlatform/PlayGamesPlatform.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/ISocialPlatform/PlayGamesPlatform.cs
@@ -857,13 +857,17 @@ namespace GooglePlayGames
         /// <param name="collection">Collection. social or public</param>
         /// <param name="timeSpan">Time span. daily, weekly, all-time</param>
         /// <param name="callback">Callback to invoke when completed.</param>
+        /// <param name="forceReload">If true, this call will clear any locally cached data and
+        /// attempt to fetch the latest data from the server. Normally, this should be set to {@code
+        /// false} to gain advantages of data caching.</param>
         public void LoadScores(
             string leaderboardId,
             LeaderboardStart start,
             int rowCount,
             LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback)
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false)
         {
             if (!IsAuthenticated())
             {
@@ -880,7 +884,8 @@ namespace GooglePlayGames
                 rowCount,
                 collection,
                 timeSpan,
-                callback);
+                callback,
+                forceReload);
         }
 
         /// <summary>

--- a/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/Platforms/Android/AndroidClient.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/Platforms/Android/AndroidClient.cs
@@ -780,7 +780,8 @@ namespace GooglePlayGames.Android
         public void LoadScores(string leaderboardId, LeaderboardStart start,
             int rowCount, LeaderboardCollection collection,
             LeaderboardTimeSpan timeSpan,
-            Action<LeaderboardScoreData> callback)
+            Action<LeaderboardScoreData> callback,
+            bool forceReload = false)
         {
             using (var client = getLeaderboardsClient())
             {
@@ -791,7 +792,8 @@ namespace GooglePlayGames.Android
                     leaderboardId,
                     AndroidJavaConverter.ToLeaderboardVariantTimeSpan(timeSpan),
                     AndroidJavaConverter.ToLeaderboardVariantCollection(collection),
-                    rowCount))
+                    rowCount,
+                    forceReload))
                 {
                     AndroidTaskUtils.AddOnSuccessListener<AndroidJavaObject>(
                         task,


### PR DESCRIPTION
Added forceReload param based on the doc: https://developers.google.com/android/reference/com/google/android/gms/games/LeaderboardsClient#public-abstract-taskannotateddataleaderboardsclient.leaderboardscores-loadplayercenteredscores-string-leaderboardid,-int-span,-int-leaderboardcollection,-int-maxresults,-boolean-forcereload