### PR TITLE
Set PlayGamesAchievement class to public

### DIFF
--- a/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/ISocialPlatform/PlayGamesAchievement.cs
+++ b/Assets/Public/GooglePlayGames/com.google.play.games/Runtime/Scripts/ISocialPlatform/PlayGamesAchievement.cs
@@ -39,7 +39,7 @@ namespace GooglePlayGames
     /// to the API, offering identical functionality as <see cref="PlayGamesPlatform.ReportProgress" />.
     /// Implements both the <see cref="IAchievement"/> and <see cref="IAchievementDescription"/> interfaces.
     /// </summary>
-    internal class PlayGamesAchievement : IAchievement, IAchievementDescription
+    public class PlayGamesAchievement : IAchievement, IAchievementDescription
     {
         /// <summary>
         /// The callback for reporting progress.


### PR DESCRIPTION
Gives access to properties not present in the IAchievement and IAchievementDescription interfaces that are vital for constructing bespoke achievement UI.